### PR TITLE
Adds fax machines to Lima and Pubby

### DIFF
--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -767,6 +767,8 @@
 "arn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/fax_machine/recieving_disabled,
+/obj/structure/table/reinforced,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/warden)
 "ars" = (
@@ -2126,6 +2128,8 @@
 	name = "Chapel RC";
 	pixel_y = 30
 	},
+/obj/machinery/fax_machine/recieving_disabled,
+/obj/structure/table/wood,
 /turf/open/floor/carpet/red,
 /area/station/service/chapel/office)
 "aVV" = (
@@ -3182,8 +3186,8 @@
 "bpf" = (
 /obj/machinery/light/directional/west,
 /obj/structure/table/wood,
-/obj/item/flashlight/lamp,
 /obj/machinery/firealarm/directional/west,
+/obj/machinery/fax_machine/recieving_disabled,
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
 "bpl" = (
@@ -5685,10 +5689,6 @@
 /area/station/hallway/primary/port)
 "csN" = (
 /obj/machinery/photocopier,
-/obj/item/radio/intercom{
-	pixel_x = 33;
-	pixel_y = -1
-	},
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
@@ -8722,6 +8722,8 @@
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "dzB" = (
 /obj/structure/reagent_dispensers/wall/peppertank/directional/south,
+/obj/machinery/fax_machine/recieving_disabled,
+/obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "dzG" = (
@@ -8842,6 +8844,8 @@
 /area/station/hallway/primary/port)
 "dCh" = (
 /obj/item/radio/intercom/directional/east,
+/obj/machinery/fax_machine/recieving_disabled,
+/obj/structure/table/reinforced,
 /turf/open/floor/iron/dark/smooth_edge,
 /area/station/command/heads_quarters/ce)
 "dCn" = (
@@ -8997,10 +9001,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/light_switch{
-	pixel_x = -10;
-	pixel_y = 22
-	},
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/showroomfloor,
 /area/station/command/heads_quarters/cmo)
@@ -9419,7 +9419,7 @@
 /area/station/engineering/gravity_generator)
 "dOs" = (
 /obj/structure/table/wood,
-/obj/item/clothing/accessory/lawyers_badge,
+/obj/machinery/fax_machine/recieving_disabled,
 /turf/open/floor/carpet/orange,
 /area/station/service/lawoffice)
 "dOC" = (
@@ -10262,8 +10262,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/upper)
+"ejM" = (
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/machinery/fax_machine/recieving_disabled,
+/obj/structure/table,
+/turf/open/floor/iron,
+/area/station/cargo/office)
 "ejQ" = (
-/obj/structure/closet/firecloset,
+/obj/structure/tank_dispenser{
+	pixel_x = -1
+	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
@@ -11028,6 +11036,7 @@
 	pixel_x = -24;
 	pixel_y = 24
 	},
+/obj/item/clothing/accessory/lawyers_badge,
 /turf/open/floor/carpet/orange,
 /area/station/service/lawoffice)
 "eyG" = (
@@ -12940,9 +12949,8 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "fha" = (
-/obj/structure/tank_dispenser{
-	pixel_x = -1
-	},
+/obj/machinery/fax_machine/recieving_disabled,
+/obj/structure/table/reinforced,
 /turf/open/floor/iron/dark/smooth_half{
 	dir = 1
 	},
@@ -14996,18 +15004,7 @@
 /area/station/security/office)
 "fTy" = (
 /obj/structure/table,
-/obj/item/disk/tech_disk{
-	pixel_y = 6
-	},
-/obj/item/disk/tech_disk{
-	pixel_y = 6
-	},
-/obj/item/disk/tech_disk{
-	pixel_x = 6
-	},
-/obj/item/disk/tech_disk{
-	pixel_x = -6
-	},
+/obj/machinery/fax_machine/recieving_disabled,
 /turf/open/floor/iron/dark/smooth_corner{
 	dir = 1
 	},
@@ -15178,7 +15175,8 @@
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Central";
 	network = list("ss13","engine");
-	view_range = 10
+	view_range = 10;
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -16977,8 +16975,7 @@
 "gHz" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/food_or_drink/refreshing_beverage,
-/obj/item/pai_card,
+/obj/machinery/fax_machine/recieving_disabled,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/service)
 "gHC" = (
@@ -17624,6 +17621,7 @@
 "gTB" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/fax_machine/recieving_disabled,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "gTF" = (
@@ -19554,6 +19552,7 @@
 /obj/structure/table/wood,
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/light/directional/east,
+/obj/machinery/fax_machine/recieving_disabled,
 /turf/open/floor/carpet/orange,
 /area/station/security/detectives_office)
 "hEq" = (
@@ -25249,10 +25248,6 @@
 "jNA" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/start/hangover,
-/obj/machinery/door/morgue{
-	name = "Private Study";
-	req_access = list("library")
-	},
 /turf/open/floor/wood/large,
 /area/station/service/library)
 "jNE" = (
@@ -26602,13 +26597,13 @@
 /area/space)
 "klc" = (
 /obj/structure/table/glass,
-/obj/machinery/computer/security/telescreen/cmo,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/machinery/fax_machine/recieving_disabled,
 /turf/open/floor/iron/showroomfloor,
 /area/station/command/heads_quarters/cmo)
 "kll" = (
@@ -27907,17 +27902,13 @@
 /turf/open/floor/grass,
 /area/station/command/bridge_officer_office)
 "kLe" = (
-/obj/structure/rack,
-/obj/item/aicard,
-/obj/item/circuitboard/aicore{
-	pixel_x = -2;
-	pixel_y = 4
-	},
 /obj/machinery/light/directional/south,
 /obj/machinery/newscaster/directional/south,
 /obj/effect/turf_decal/siding/purple{
 	dir = 1
 	},
+/obj/structure/table,
+/obj/machinery/fax_machine/recieving_disabled,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "kLf" = (
@@ -28732,6 +28723,8 @@
 /area/station/engineering/atmos/upper)
 "lae" = (
 /obj/item/radio/intercom/directional/south,
+/obj/machinery/fax_machine/recieving_disabled,
+/obj/structure/table,
 /turf/open/floor/iron/showroomfloor,
 /area/station/tcommsat/computer)
 "lag" = (
@@ -30775,13 +30768,17 @@
 /area/station/maintenance/disposal)
 "lLb" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/box/deputy,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/radio/intercom,
+/obj/item/storage/box/deputy{
+	pixel_x = 7;
+	pixel_y = 14
+	},
 /turf/open/floor/iron/dark/smooth_half,
 /area/station/security/office)
 "lLi" = (
@@ -32215,6 +32212,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
+"mlO" = (
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 8
+	},
+/obj/machinery/fax_machine/recieving_disabled,
+/obj/structure/table/glass,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "mmf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -32969,6 +32974,11 @@
 /obj/item/stamp/rd,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/item/pai_card{
+	pixel_x = 6;
+	pixel_y = 7
+	},
+/obj/item/aicard,
 /turf/open/floor/iron/showroomfloor,
 /area/station/command/heads_quarters/rd)
 "mzt" = (
@@ -35224,7 +35234,7 @@
 /area/station/maintenance/port/lower)
 "nqj" = (
 /obj/structure/table/wood,
-/obj/item/storage/fancy/donut_box,
+/obj/machinery/fax_machine/recieving_disabled,
 /turf/open/floor/carpet/royalblue,
 /area/station/command/heads_quarters/captain)
 "nqt" = (
@@ -37783,6 +37793,7 @@
 /obj/machinery/light/directional/south,
 /obj/machinery/firealarm/directional/south,
 /obj/structure/table,
+/obj/machinery/fax_machine/recieving_disabled,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
 "omJ" = (
@@ -43066,7 +43077,6 @@
 /area/station/medical/surgery)
 "qli" = (
 /obj/structure/table,
-/obj/item/clipboard,
 /obj/item/radio/intercom/directional/south,
 /obj/machinery/keycard_auth/directional/east{
 	pixel_y = 8
@@ -43078,6 +43088,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 6
 	},
+/obj/machinery/fax_machine/recieving_disabled,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
 "qlF" = (
@@ -43736,9 +43747,10 @@
 /area/station/service/library)
 "qwW" = (
 /obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/folder/yellow,
-/obj/item/stamp/qm,
+/obj/item/paper_bin{
+	pixel_y = 8;
+	pixel_x = 6
+	},
 /obj/machinery/requests_console{
 	announcementConsole = 1;
 	department = "Quartermaster's Desk";
@@ -43747,6 +43759,12 @@
 	pixel_y = -30
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/item/clipboard{
+	pixel_x = -10;
+	pixel_y = 7
+	},
+/obj/item/folder/yellow,
+/obj/item/stamp/qm,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
 "qwY" = (
@@ -46820,7 +46838,8 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/structure/sign/poster/official/random{
+/obj/machinery/computer/security/telescreen/cmo{
+	dir = 8;
 	pixel_x = 32
 	},
 /turf/open/floor/iron/showroomfloor,
@@ -49756,6 +49775,15 @@
 /area/station/maintenance/port/lower)
 "sFJ" = (
 /obj/machinery/computer/rdconsole,
+/obj/item/disk/tech_disk{
+	pixel_y = 6
+	},
+/obj/item/disk/tech_disk{
+	pixel_x = -6
+	},
+/obj/item/disk/tech_disk{
+	pixel_x = 6
+	},
 /turf/open/floor/iron/dark/smooth_half,
 /area/station/science/lab)
 "sFM" = (
@@ -51725,15 +51753,15 @@
 /obj/item/taperecorder{
 	pixel_x = -3
 	},
-/obj/item/pai_card{
-	pixel_x = -3;
-	pixel_y = 3
-	},
 /obj/item/computer_hardware/hard_drive/portable/ordnance,
 /obj/item/computer_hardware/hard_drive/portable/ordnance,
 /obj/item/computer_hardware/hard_drive/portable/ordnance,
 /obj/effect/turf_decal/siding/purple{
 	dir = 5
+	},
+/obj/item/circuitboard/aicore{
+	pixel_x = -2;
+	pixel_y = 4
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
@@ -61528,6 +61556,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/firealarm/directional/south,
+/obj/machinery/light_switch/directional/south{
+	pixel_x = -8
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/command/heads_quarters/cmo)
 "xlS" = (
@@ -94211,7 +94242,7 @@ rAj
 qTX
 kEQ
 xyF
-uTG
+ejM
 oPC
 pMl
 uhc
@@ -101392,7 +101423,7 @@ teO
 bpq
 mfb
 sEC
-eCP
+mlO
 eCP
 eCP
 aXF

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -421,6 +421,8 @@
 "aeL" = (
 /obj/effect/turf_decal/tile/red,
 /obj/structure/cable,
+/obj/machinery/fax_machine/recieving_disabled,
+/obj/structure/table/wood,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
 "aeP" = (
@@ -1386,8 +1388,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
 "aop" = (
-/obj/structure/bed/dogbed/mcgriff,
-/mob/living/simple_animal/pet/dog/pug/mcgriff,
 /obj/machinery/requests_console/directional/west{
 	department = "Security";
 	departmentType = 5;
@@ -2110,13 +2110,13 @@
 /area/station/command/heads_quarters/captain)
 "axT" = (
 /obj/structure/table/wood,
-/obj/machinery/recharger,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /obj/structure/window/reinforced{
 	dir = 1
 	},
+/obj/machinery/fax_machine/recieving_disabled,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain)
 "axV" = (
@@ -2871,10 +2871,7 @@
 /area/station/maintenance/department/cargo)
 "aEm" = (
 /obj/structure/table/wood,
-/obj/item/flashlight/lamp{
-	pixel_x = 3;
-	pixel_y = 6
-	},
+/obj/machinery/fax_machine/recieving_disabled,
 /turf/open/floor/carpet,
 /area/station/security/detectives_office)
 "aEn" = (
@@ -4014,6 +4011,8 @@
 	dir = 6
 	},
 /obj/structure/cable,
+/obj/machinery/fax_machine/recieving_disabled,
+/obj/structure/table,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/qm)
 "aPi" = (
@@ -6958,6 +6957,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/fax_machine/recieving_disabled,
+/obj/structure/table/glass,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "byl" = (
@@ -13772,6 +13773,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/table/wood,
+/obj/machinery/recharger,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/captain)
 "dUZ" = (
@@ -17874,6 +17877,8 @@
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet/directional/north,
+/obj/machinery/fax_machine/recieving_disabled,
+/obj/structure/table,
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
 "fPq" = (
@@ -18109,7 +18114,8 @@
 /area/station/engineering/supermatter/room)
 "fVX" = (
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/recharge_station,
+/obj/machinery/fax_machine/recieving_disabled,
+/obj/structure/table,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "fWn" = (
@@ -19651,6 +19657,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
+/obj/machinery/fax_machine/recieving_disabled,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "gDd" = (
@@ -20374,6 +20381,9 @@
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet/directional/north,
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/pen/fountain,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
 "gSH" = (
@@ -20385,6 +20395,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "gSV" = (
+/obj/machinery/fax_machine/recieving_disabled,
+/obj/structure/table/wood,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "gSX" = (
@@ -21035,6 +21047,8 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/machinery/fax_machine/recieving_disabled,
+/obj/structure/table,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/service)
 "hky" = (
@@ -22957,6 +22971,8 @@
 /area/station/maintenance/department/science)
 "ihO" = (
 /obj/machinery/airalarm/directional/north,
+/obj/machinery/fax_machine/recieving_disabled,
+/obj/structure/table/wood,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
 "ihY" = (
@@ -24243,6 +24259,8 @@
 /area/station/hallway/secondary/entry)
 "iPr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/fax_machine/recieving_disabled,
+/obj/structure/table/reinforced,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
 "iPu" = (
@@ -26789,6 +26807,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/fax_machine/recieving_disabled,
+/obj/structure/table,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "kbt" = (
@@ -31067,6 +31087,16 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/science/lab)
+"lYH" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/fax_machine/recieving_disabled,
+/obj/structure/table/glass,
+/turf/open/floor/iron/white,
+/area/station/medical/pharmacy)
 "lYL" = (
 /obj/machinery/holopad,
 /obj/structure/disposalpipe/segment{
@@ -42894,6 +42924,8 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/machinery/fax_machine/recieving_disabled,
+/obj/structure/table,
 /turf/open/floor/iron/white,
 /area/station/science/lab)
 "ruv" = (
@@ -46595,6 +46627,8 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/structure/bed/dogbed/mcgriff,
+/mob/living/simple_animal/pet/dog/pug/mcgriff,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/warden)
 "tlc" = (
@@ -47619,6 +47653,7 @@
 	},
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
+/obj/machinery/fax_machine/recieving_disabled,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "tGQ" = (
@@ -49803,6 +49838,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
+"uIw" = (
+/obj/machinery/fax_machine/recieving_disabled,
+/obj/structure/table/reinforced,
+/turf/open/floor/iron/showroomfloor,
+/area/station/security/warden)
 "uIP" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -53388,6 +53428,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
+"wso" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/fax_machine/recieving_disabled,
+/obj/structure/table/wood,
+/turf/open/floor/iron/white,
+/area/station/medical/psychology)
 "wsr" = (
 /obj/structure/bookcase/random/religion,
 /obj/machinery/light/small{
@@ -55985,6 +56034,20 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/exit/departure_lounge)
+"xuX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/fax_machine/recieving_disabled,
+/obj/structure/table/wood,
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/hop)
 "xvh" = (
 /obj/effect/landmark/start/security_officer,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
@@ -79722,7 +79785,7 @@ alz
 amg
 icL
 usu
-anI
+uIw
 aoS
 eWZ
 qcC
@@ -82622,7 +82685,7 @@ tZn
 vgg
 nZP
 ghL
-lGQ
+wso
 nPg
 gsP
 bOI
@@ -89031,7 +89094,7 @@ brZ
 dpu
 mWL
 wtt
-fjB
+lYH
 aIB
 rtY
 oKT
@@ -91302,7 +91365,7 @@ gtH
 aAH
 aBC
 hQV
-aDU
+xuX
 aEN
 aAH
 tVk


### PR DESCRIPTION
Upstream added faxes.
We had faxes.
Now I have a right to use them more.

Might've missed a few key areas but whatever.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Jolly
qol: On Pubby, there are now more fax machines.
qol: On Lima, there are now more fax machines.
fix: On Lima, there is no longer a rogue door in the library.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
