### PR TITLE
Some QoL to our fax machines

### DIFF
--- a/talestation_modules/code/game/machinery/fax_machine.dm
+++ b/talestation_modules/code/game/machinery/fax_machine.dm
@@ -5,7 +5,7 @@
 GLOBAL_LIST_EMPTY(fax_machines)
 
 /// Cooldown for fax time between faxes.
-#define FAX_COOLDOWN_TIME 3 MINUTES
+#define FAX_COOLDOWN_TIME 1 MINUTES
 
 /// The time between alerts that the machine contains an unread message.
 #define FAX_UNREAD_ALERT_TIME 3 MINUTES
@@ -206,7 +206,13 @@ GLOBAL_LIST_EMPTY(fax_machines)
 			obj_flags &= ~EMAGGED
 
 		if("toggle_recieving")
-			can_receive_paperwork = !can_receive_paperwork
+			if(allowed(usr))
+				can_receive_paperwork = !can_receive_paperwork
+				balloon_alert(usr, span_notice("Reciving toggled."))
+				playsound(src, 'sound/machines/terminal_processing.ogg', 50, FALSE)
+			else
+				balloon_alert(usr, span_notice("No access!"))
+				playsound(src, 'sound/machines/terminal_error.ogg', 50, FALSE)
 
 		if("read_last_received")
 			unread_message = FALSE

--- a/tgui/packages/tgui/interfaces/_FaxMachine.js
+++ b/tgui/packages/tgui/interfaces/_FaxMachine.js
@@ -189,7 +189,8 @@ export const _FaxMachine = (props, context) => {
               tooltip={
                 (can_receive ? 'Disable' : 'Enable') +
                 ' the ability for this fax machine \
-                to receive paperwork every five minutes.'
+                to receive paperwork every five minutes, \
+                if you have the access to do so.'
               }
               onClick={() => act('toggle_recieving')}
             />


### PR DESCRIPTION
The bounty minigame now requires access to use.
Also, sending faxes now is only on a 1 min cooldown.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Jolly
qol: Fax machines now only have a 60s delay to send faxes.
qol: Fax machines bounty mini-game has been locked behind those with ACCESS_COMMAND and ACCESS_LAWYER.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
