### PR TITLE
pixel shifting but better

### DIFF
--- a/talestation_modules/code/modules/mob/pixel_shift.dm
+++ b/talestation_modules/code/modules/mob/pixel_shift.dm
@@ -180,7 +180,9 @@
 	if(!istype(living_mob))
 		return
 
-	var/movement = user.next_move_dir_add & ~user.next_move_dir_sub
+	var/movement
+	for(var/_key in user?.keys_held)
+		movement = movement | user.movement_keys[_key]
 	if(movement & NORTH)
 		living_mob.pixelshift_north()
 	if(movement & SOUTH)

--- a/talestation_modules/code/modules/mob/pixel_shift.dm
+++ b/talestation_modules/code/modules/mob/pixel_shift.dm
@@ -1,247 +1,143 @@
 /// -- Pixelshifting UI and component. --
 /// Keybinding hotkey signal.
-#define COMSIG_KB_LIVING_PIXELSHIFT "pixelshift"
-
-/// Signals to pixelshift certain directions.
-#define COMSIG_PIXELSHIFT_POSY "pixelshift_posy"
-#define COMSIG_PIXELSHIFT_POSX "pixelshift_posx"
-#define COMSIG_PIXELSHIFT_NEGY "pixelshift_negy"
-#define COMSIG_PIXELSHIFT_NEGX "pixelshift_negx"
-
-/// Signal to reset the user's pixelshift, but not stop pixelshifting.
-#define COMSIG_PIXELSHIFT_RESET "pixelshift_reset"
-/// Signal to stop pixelshifting.
-#define COMSIG_PIXELSHIFT_STOP "pixelshift_stop"
+#define COMSIG_KB_MOVEMENT_PIXELSHIFT_DOWN "keybinding_movement_pixelshift_down"
+#define COMSIG_KB_MOVEMENT_PIXELSHIFT_RESET_DOWN "keybinding_movement_pixelshift_reset_down"
 
 /// Defines for mins and maxs of x and y shifts.
 #define PIXELSHIFT_Y_LIMIT 16
 #define PIXELSHIFT_X_LIMIT 16
 
-/// prevent_movement can_use implementation to stop unlocking movement while pixel shifted.
-/datum/keybinding/mob/prevent_movement/can_use(client/user)
-	var/mob/living/our_mob = user.mob
-	if(istype(our_mob))
-		if(our_mob.pixel_shifted)
-			return FALSE
+/client/var/pixelshifting = FALSE
+/mob/living/var/pixelshift_movement_reset = TRUE
+/mob/living/var/pixelshift_x = 0
+/mob/living/var/pixelshift_y = 0
+
+/mob/living/verb/toggle_pixelshift_movement_reset()
+	set name = "Toggle Pixelshift Reset on Movement"
+	set category = "Pixelshift"
+
+	pixelshift_movement_reset = !pixelshift_movement_reset
+	to_chat(src, span_notice("Pixelshifts will [(pixelshift_movement_reset ? "now" : "no longer")] reset on movements."))
+
+/mob/living/Move(atom/newloc, direct, glide_size_override)
+	if(pixelshift_movement_reset)
+		pixelshift_x = pixelshift_y = 0
+		update_pixelshift()
 	return ..()
 
-/// Keybind to open up the pixelshift UI / toggle pixelshifting.
+/mob/living/verb/reset_pixelshift()
+	set name = "Reset Pixelshift"
+	set category = "Pixelshift"
+
+	pixelshift_x = 0
+	pixelshift_y = 0
+	update_pixelshift()
+
+/mob/living/verb/pixelshift_north()
+	set name = "Shift North"
+	set category = "Pixelshift"
+
+	if(pixelshift_y >= PIXELSHIFT_Y_LIMIT)
+		return
+
+	pixelshift_y++
+	update_pixelshift()
+
+/mob/living/verb/pixelshift_south()
+	set name = "Shift South"
+	set category = "Pixelshift"
+
+	if(pixelshift_y <= -PIXELSHIFT_Y_LIMIT)
+		return
+
+	pixelshift_y--
+	update_pixelshift()
+
+/mob/living/verb/pixelshift_west()
+	set name = "Shift West"
+	set category = "Pixelshift"
+
+	if(pixelshift_x <= -PIXELSHIFT_X_LIMIT)
+		return
+
+	pixelshift_x--
+	update_pixelshift()
+
+/mob/living/verb/pixelshift_east()
+	set name = "Shift East"
+	set category = "Pixelshift"
+
+	if(pixelshift_x >= PIXELSHIFT_X_LIMIT)
+		return
+
+	pixelshift_x++
+	update_pixelshift()
+
+/mob/living/proc/update_pixelshift()
+	pixel_x = base_pixel_x + pixelshift_x
+	pixel_y = base_pixel_y + pixelshift_y
+
 /datum/keybinding/mob/living/pixel_shift
-	hotkey_keys = list("AltB")
+	hotkey_keys = list("'")
 	name = "pixelshift"
-	full_name = "Toggle Pixel Shift"
-	description = "Toggles the Pixel Shift UI open and closed."
-	keybind_signal = COMSIG_KB_LIVING_PIXELSHIFT
-	category = CATEGORY_CARBON
+	full_name = "Hold Pixel Shift"
+	description = "Hold to activate pixel shifting. ITS IMPORTANT THAT THIS IS A SINGLE KEY AND DOES NOT CONFLICT WITH ANYTHING ELSE"
+	keybind_signal = COMSIG_KB_MOVEMENT_PIXELSHIFT_DOWN
+	category = CATEGORY_MOVEMENT
+
+/datum/keybinding/mob/living/pixel_shift_reset
+	hotkey_keys = list(";")
+	name = "pixelshift_reset"
+	full_name = "Reset Pixel Shift"
+	description = "Press to reset your pixel shift."
+	keybind_signal = COMSIG_KB_MOVEMENT_PIXELSHIFT_RESET_DOWN
+	category = CATEGORY_MOVEMENT
+
+/datum/keybinding/mob/living/pixel_shift_reset/down(client/user)
+	. = ..()
+	var/mob/living/user_mob = user.mob
+	if(istype(user_mob))
+		user_mob.reset_pixelshift()
 
 /datum/keybinding/mob/living/pixel_shift/down(client/user)
 	. = ..()
-	var/mob/living/our_mob = user.mob
-	if(!istype(our_mob))
-		return
+	user.pixelshifting = TRUE
 
-	if(our_mob.pixel_shifted)
-		SEND_SIGNAL(our_mob, COMSIG_PIXELSHIFT_STOP)
-	else
-		if(our_mob.stat != CONSCIOUS)
-			to_chat(src, span_danger("You need to be conscious to use pixel shifting."))
-			return
-
-		if(our_mob.incapacitated())
-			to_chat(src, span_danger("You aren't able to use pixel shifting right now."))
-			return
-
-		var/datum/pixel_shift_ui/tgui = new(our_mob)
-		tgui.ui_interact(our_mob)
-
-/mob/living
-	/// Whether we are currently pixel-shifted.
-	var/pixel_shifted = FALSE
-
-/// A verb to open up the pixel shift UI and enable pixel shifting.
-/mob/living/verb/open_pixel_shift_ui()
-	set name = "Pixel Shift"
-	set category = "IC"
-
-	if(pixel_shifted)
-		return
-
-	if(stat != CONSCIOUS)
-		to_chat(src, span_danger("You need to be conscious to use pixel shifting."))
-		return
-
-	if(incapacitated())
-		to_chat(src, span_danger("You aren't able to use pixel shifting right now."))
-		return
-
-	var/datum/pixel_shift_ui/tgui = new(src)
-	tgui.ui_interact(src)
-
-/// Datum to hold the pixel shift UI and enable pixel shifting.
-/datum/pixel_shift_ui
-	/// the living mob that's using our UI
-	var/mob/living/ui_user
-
-/datum/pixel_shift_ui/New(mob/living/user)
-	ui_user = user
-	ui_user.AddComponent(/datum/component/pixel_shift)
-
-/datum/pixel_shift_ui/Destroy(force, ...)
-	ui_user = null
-	return ..()
-
-/datum/pixel_shift_ui/ui_close(mob/user)
-	SEND_SIGNAL(ui_user, COMSIG_PIXELSHIFT_STOP)
-	qdel(src)
-
-/datum/pixel_shift_ui/ui_status(mob/user, datum/ui_state/state)
-	if(!ui_user.pixel_shifted)
-		return UI_CLOSE
-	if(ui_user.stat != CONSCIOUS)
-		return UI_CLOSE
-	if(ui_user.incapacitated())
-		return UI_DISABLED
-	return UI_INTERACTIVE
-
-/datum/pixel_shift_ui/ui_data(mob/user)
-	var/list/data = list()
-	data["x_shift"] = ui_user.pixel_x
-	data["y_shift"] = ui_user.pixel_y
-
-	return data
-
-/datum/pixel_shift_ui/ui_interact(mob/user, datum/tgui/ui)
-	ui = SStgui.try_update_ui(user, src, ui)
-	if(!ui)
-		ui = new(user, src, "_PixelShift")
-		ui.open()
-
-/datum/pixel_shift_ui/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
+/datum/keybinding/mob/living/pixel_shift/up(client/user)
 	. = ..()
-	if(.)
-		return
+	user.pixelshifting = FALSE
+	// prevents accidental movements right after releasing
+	user.next_move_dir_sub = ALL
 
-	switch(action)
-		if("shift_posx")
-			SEND_SIGNAL(ui_user, COMSIG_PIXELSHIFT_POSX)
-		if("shift_negx")
-			SEND_SIGNAL(ui_user, COMSIG_PIXELSHIFT_NEGX)
-		if("shift_posy")
-			SEND_SIGNAL(ui_user, COMSIG_PIXELSHIFT_POSY)
-		if("shift_negy")
-			SEND_SIGNAL(ui_user, COMSIG_PIXELSHIFT_NEGY)
-		if("reset_shift")
-			SEND_SIGNAL(ui_user, COMSIG_PIXELSHIFT_RESET)
+/mob/living/keyLoop(client/user)
+	if(!user.pixelshifting)
+		return ..()
+	return
 
-	return TRUE
+/datum/keybinding/movement/north/down(client/user)
+	if(!user.pixelshifting)
+		return ..()
+	var/mob/living/user_mob = user.mob
+	if(istype(user_mob))
+		user_mob.pixelshift_north()
 
-/// Pixel shift component, applied to any mob/living.
-/// Allows the user to shift around their pixel_x and pixel_y offset.
-/// This component tracks their shifting and updates their offsets as they pixelshift.
-/datum/component/pixel_shift
-	dupe_mode = COMPONENT_DUPE_UNIQUE
-	/// The parent, typecasted to mob/living.
-	var/mob/living/living_parent
-	/// Our shift on the X axis.
-	var/x_shift = 0
-	/// Our shift on the Y axis.
-	var/y_shift = 0
+/datum/keybinding/movement/south/down(client/user)
+	if(!user.pixelshifting)
+		return ..()
+	var/mob/living/user_mob = user.mob
+	if(istype(user_mob))
+		user_mob.pixelshift_south()
 
-/datum/component/pixel_shift/Initialize()
-	if(!isliving(parent))
-		return COMPONENT_INCOMPATIBLE
+/datum/keybinding/movement/east/down(client/user)
+	if(!user.pixelshifting)
+		return ..()
+	var/mob/living/user_mob = user.mob
+	if(istype(user_mob))
+		user_mob.pixelshift_east()
 
-	src.living_parent = parent
-	if(living_parent)
-		living_parent.client.movement_locked = TRUE
-		living_parent.pixel_shifted = TRUE
-	src.x_shift = living_parent.pixel_x
-	src.y_shift = living_parent.pixel_y
-
-	// Moving at all or the RESET signal will reset the offsets to the base_pixel.
-	RegisterSignal(parent, list(COMSIG_MOVABLE_PRE_MOVE, COMSIG_PIXELSHIFT_RESET), .proc/reset_offsets)
-	// Movement keys in any direction or the pixelshift signals will move the user in a direction.
-	RegisterSignal(parent, list(COMSIG_KB_MOVEMENT_NORTH_DOWN, COMSIG_PIXELSHIFT_POSY), .proc/shift_pos_y)
-	RegisterSignal(parent, list(COMSIG_KB_MOVEMENT_EAST_DOWN, COMSIG_PIXELSHIFT_POSX), .proc/shift_pos_x)
-	RegisterSignal(parent, list(COMSIG_KB_MOVEMENT_SOUTH_DOWN, COMSIG_PIXELSHIFT_NEGY), .proc/shift_neg_y)
-	RegisterSignal(parent, list(COMSIG_KB_MOVEMENT_WEST_DOWN, COMSIG_PIXELSHIFT_NEGX), .proc/shift_neg_x)
-	// Resist, getting pulled, or the STOP signal will reset the user and qdel the component.
-	RegisterSignal(parent, list(COMSIG_LIVING_RESIST, COMSIG_LIVING_GET_PULLED, COMSIG_PIXELSHIFT_STOP), .proc/stop_pixel_shift)
-
-	to_chat(parent, span_notice("You are now pixel shifting. Movement has been locked. <b>Resist</b> or close the UI to stop pixel shifting."))
-
-/datum/component/pixel_shift/Destroy()
-	reset_offsets()
-	living_parent.client.movement_locked = FALSE
-	living_parent.pixel_shifted = FALSE
-	living_parent = null
-	UnregisterSignal(parent, list(
-		COMSIG_MOVABLE_PRE_MOVE,
-		COMSIG_PIXELSHIFT_RESET,
-		COMSIG_LIVING_RESIST,
-		COMSIG_LIVING_GET_PULLED,
-		COMSIG_PIXELSHIFT_STOP,
-		COMSIG_KB_MOVEMENT_NORTH_DOWN,
-		COMSIG_PIXELSHIFT_POSY,
-		COMSIG_KB_MOVEMENT_EAST_DOWN,
-		COMSIG_PIXELSHIFT_POSX,
-		COMSIG_KB_MOVEMENT_SOUTH_DOWN,
-		COMSIG_PIXELSHIFT_NEGY,
-		COMSIG_KB_MOVEMENT_WEST_DOWN,
-		COMSIG_PIXELSHIFT_NEGX,
-	))
-
-	to_chat(parent, span_notice("You are no longer pixel shifting. Movement has been unlocked."))
-	return ..()
-
-/// Shifts the user in the positive y direction (up)
-/datum/component/pixel_shift/proc/shift_pos_y(datum/source)
-	SIGNAL_HANDLER
-
-	var/adjusted_min_y = -PIXELSHIFT_Y_LIMIT + living_parent.base_pixel_y + living_parent.body_position_pixel_y_offset
-	var/adjusted_max_y = PIXELSHIFT_Y_LIMIT + living_parent.base_pixel_y + living_parent.body_position_pixel_y_offset
-	y_shift = clamp(y_shift + 1, adjusted_min_y, adjusted_max_y)
-	update_offsets()
-
-/// Shifts the user in the positive X direction (Right)
-/datum/component/pixel_shift/proc/shift_pos_x(datum/source)
-	SIGNAL_HANDLER
-
-	x_shift = clamp(x_shift + 1, -PIXELSHIFT_X_LIMIT, PIXELSHIFT_X_LIMIT)
-	update_offsets()
-
-/// Shifts the user in the negative Y direction (Down)
-/datum/component/pixel_shift/proc/shift_neg_y(datum/source)
-	SIGNAL_HANDLER
-
-	var/adjusted_min_y = -PIXELSHIFT_Y_LIMIT + living_parent.base_pixel_y + living_parent.body_position_pixel_y_offset
-	var/adjusted_max_y = PIXELSHIFT_Y_LIMIT + living_parent.base_pixel_y + living_parent.body_position_pixel_y_offset
-	y_shift = clamp(y_shift - 1, adjusted_min_y, adjusted_max_y)
-	update_offsets()
-
-/// Shifts the user in the negative X direction (Left)
-/datum/component/pixel_shift/proc/shift_neg_x(datum/source)
-	SIGNAL_HANDLER
-
-	x_shift = clamp(x_shift - 1, -PIXELSHIFT_X_LIMIT, PIXELSHIFT_X_LIMIT)
-	update_offsets()
-
-/// Resets the user's x and y shift to their base_pixel (+ any position offset)
-/datum/component/pixel_shift/proc/reset_offsets()
-	SIGNAL_HANDLER
-
-	x_shift = living_parent.base_pixel_x + living_parent.body_position_pixel_x_offset
-	y_shift = living_parent.base_pixel_y + living_parent.body_position_pixel_y_offset
-	update_offsets()
-
-/// Resets the user's pixel offsets and qdel's the component
-/datum/component/pixel_shift/proc/stop_pixel_shift()
-	SIGNAL_HANDLER
-
-	reset_offsets()
-	qdel(src)
-
-/// Actually update the user's pixel offsets based on our shifts
-/datum/component/pixel_shift/proc/update_offsets()
-	living_parent.pixel_x = x_shift
-	living_parent.pixel_y = y_shift
+/datum/keybinding/movement/west/down(client/user)
+	if(!user.pixelshifting)
+		return ..()
+	var/mob/living/user_mob = user.mob
+	if(istype(user_mob))
+		user_mob.pixelshift_west()

--- a/talestation_modules/code/modules/mob/pixel_shift.dm
+++ b/talestation_modules/code/modules/mob/pixel_shift.dm
@@ -126,11 +126,20 @@
 
 /datum/keybinding/mob/living/pixel_shift
 	hotkey_keys = list("'")
-	name = "pixelshift"
+	name = "pixelshifthold"
 	full_name = "Hold Pixel Shift"
 	description = "Hold to activate pixel shifting. ITS IMPORTANT THAT THIS IS A SINGLE KEY AND DOES NOT CONFLICT WITH ANYTHING ELSE"
 	keybind_signal = COMSIG_KB_MOVEMENT_PIXELSHIFT_DOWN
 	category = CATEGORY_MOVEMENT
+
+/datum/keybinding/mob/living/pixel_shift_toggle
+	hotkey_keys = list("\[")
+	name = "pixelshifttoggle"
+	full_name = "Toggle Pixel Shift"
+	description = "Press to toggle pixel shifting. ITS IMPORTANT THAT THIS IS A SINGLE KEY AND DOES NOT CONFLICT WITH ANYTHING ELSE"
+	keybind_signal = COMSIG_KB_MOVEMENT_PIXELSHIFT_TOGGLE_DOWN
+	category = CATEGORY_MOVEMENT
+
 
 /datum/keybinding/mob/living/pixel_shift_reset
 	hotkey_keys = list(";")
@@ -139,12 +148,6 @@
 	description = "Press to reset your pixel shift."
 	keybind_signal = COMSIG_KB_MOVEMENT_PIXELSHIFT_RESET_DOWN
 	category = CATEGORY_MOVEMENT
-
-/datum/keybinding/mob/living/pixel_shift_reset/down(client/user)
-	. = ..()
-	var/mob/living/user_mob = user.mob
-	if(istype(user_mob))
-		user_mob.reset_pixelshift()
 
 /datum/keybinding/mob/living/pixel_shift/down(client/user)
 	. = ..()
@@ -156,35 +159,32 @@
 	// prevents accidental movements right after releasing
 	user.next_move_dir_sub = ALL
 
+/datum/keybinding/mob/living/pixel_shift_toggle/down(client/user)
+	. = ..()
+	user.pixelshifting = !user.pixelshifting
+	if(!user.pixelshifting)
+		user.next_move_dir_sub = ALL
+	to_chat(user, span_notice("Pixel Shifting is now [(user.pixelshifting ? "enabled" : "disabled")]"))
+
+/datum/keybinding/mob/living/pixel_shift_reset/down(client/user)
+	. = ..()
+	var/mob/living/user_mob = user.mob
+	if(istype(user_mob))
+		user_mob.reset_pixelshift()
+
 /mob/living/keyLoop(client/user)
 	if(!user.pixelshifting)
 		return ..()
-	return
+	var/mob/living/living_mob = user.mob
+	if(!istype(living_mob))
+		return
 
-/datum/keybinding/movement/north/down(client/user)
-	if(!user.pixelshifting)
-		return ..()
-	var/mob/living/user_mob = user.mob
-	if(istype(user_mob))
-		user_mob.pixelshift_north()
-
-/datum/keybinding/movement/south/down(client/user)
-	if(!user.pixelshifting)
-		return ..()
-	var/mob/living/user_mob = user.mob
-	if(istype(user_mob))
-		user_mob.pixelshift_south()
-
-/datum/keybinding/movement/east/down(client/user)
-	if(!user.pixelshifting)
-		return ..()
-	var/mob/living/user_mob = user.mob
-	if(istype(user_mob))
-		user_mob.pixelshift_east()
-
-/datum/keybinding/movement/west/down(client/user)
-	if(!user.pixelshifting)
-		return ..()
-	var/mob/living/user_mob = user.mob
-	if(istype(user_mob))
-		user_mob.pixelshift_west()
+	var/movement = user.next_move_dir_add & ~user.next_move_dir_sub
+	if(movement & NORTH)
+		living_mob.pixelshift_north()
+	if(movement & SOUTH)
+		living_mob.pixelshift_south()
+	if(movement & EAST)
+		living_mob.pixelshift_east()
+	if(movement & WEST)
+		living_mob.pixelshift_west()

--- a/talestation_modules/code/modules/mob/pixel_shift.dm
+++ b/talestation_modules/code/modules/mob/pixel_shift.dm
@@ -13,9 +13,16 @@
 /mob/living/var/pixelshift_x = 0
 /mob/living/var/pixelshift_y = 0
 
+/datum/config_entry/flag/pixelshift_toggle_allow
+	default = FALSE
+
 /mob/living/verb/toggle_pixelshift_movement_reset()
 	set name = "Toggle Pixelshift Reset on Movement"
 	set category = "Pixelshift"
+
+	if(!CONFIG_GET(/datum/config_entry/flag/pixelshift_toggle_allow))
+		to_chat(src, span_warning("This feature is disabled via config."))
+		return
 
 	pixelshift_movement_reset = !pixelshift_movement_reset
 	to_chat(src, span_notice("Pixelshifts will [(pixelshift_movement_reset ? "now" : "no longer")] reset on movements."))

--- a/talestation_modules/code/modules/mob/pixel_shift.dm
+++ b/talestation_modules/code/modules/mob/pixel_shift.dm
@@ -25,6 +25,37 @@
 		update_pixelshift()
 	return ..()
 
+/mob/living/Initialize(mapload)
+	RegisterSignal(src, SIGNAL_ADDTRAIT(TRAIT_RESTRAINED), .proc/reset_pixelshift)
+	return ..()
+
+/mob/living/Destroy()
+	UnregisterSignal(SIGNAL_ADDTRAIT(TRAIT_RESTRAINED))
+	return ..()
+
+/mob/living/proc/allow_pixelshifting()
+	if(stat)
+		return FALSE
+	if(IsStun())
+		return FALSE
+	if(HAS_TRAIT(src, TRAIT_RESTRAINED))
+		return FALSE
+	return TRUE
+
+/mob/living/set_stat(new_stat)
+	. = ..()
+	if(!allow_pixelshifting())
+		reset_pixelshift()
+
+/mob/living/SetStun(amount, ignore_canstun)
+	. = ..()
+	if(!allow_pixelshifting())
+		reset_pixelshift()
+
+/mob/living/_add_trait(datum/thing, trait, source)
+	. = ..()
+
+
 /mob/living/verb/reset_pixelshift()
 	set name = "Reset Pixelshift"
 	set category = "Pixelshift"
@@ -74,8 +105,8 @@
 	update_pixelshift()
 
 /mob/living/proc/update_pixelshift()
-	pixel_x = base_pixel_x + pixelshift_x
-	pixel_y = base_pixel_y + pixelshift_y
+	pixel_x = base_pixel_x + pixelshift_x + body_position_pixel_x_offset
+	pixel_y = base_pixel_y + pixelshift_y + body_position_pixel_y_offset
 
 /datum/keybinding/mob/living/pixel_shift
 	hotkey_keys = list("'")

--- a/talestation_modules/code/modules/mob/pixel_shift.dm
+++ b/talestation_modules/code/modules/mob/pixel_shift.dm
@@ -25,13 +25,25 @@
 		update_pixelshift()
 	return ..()
 
-/mob/living/Initialize(mapload)
-	RegisterSignal(src, SIGNAL_ADDTRAIT(TRAIT_RESTRAINED), .verb/reset_pixelshift)
-	return ..()
+/mob/living/on_restrained_trait_gain(datum/source)
+	. = ..()
+	reset_pixelshift()
 
-/mob/living/Destroy()
-	UnregisterSignal(SIGNAL_ADDTRAIT(TRAIT_RESTRAINED))
-	return ..()
+/mob/living/on_incapacitated_trait_gain(datum/source)
+	. = ..()
+	reset_pixelshift()
+
+/mob/living/on_floored_trait_gain(datum/source)
+	. = ..()
+	reset_pixelshift()
+
+/mob/living/on_immobilized_trait_gain(datum/source)
+	. = ..()
+	reset_pixelshift()
+
+/mob/living/on_knockedout_trait_gain(datum/source)
+	. = ..()
+	reset_pixelshift()
 
 /mob/living/proc/allow_pixelshifting()
 	if(stat)
@@ -39,6 +51,14 @@
 	if(IsStun())
 		return FALSE
 	if(HAS_TRAIT(src, TRAIT_RESTRAINED))
+		return FALSE
+	if(HAS_TRAIT(src, TRAIT_INCAPACITATED))
+		return FALSE
+	if(HAS_TRAIT(src, TRAIT_FLOORED))
+		return FALSE
+	if(HAS_TRAIT(src, TRAIT_IMMOBILIZED))
+		return FALSE
+	if(HAS_TRAIT(src, TRAIT_KNOCKEDOUT))
 		return FALSE
 	return TRUE
 

--- a/talestation_modules/code/modules/mob/pixel_shift.dm
+++ b/talestation_modules/code/modules/mob/pixel_shift.dm
@@ -20,7 +20,7 @@
 	set name = "Toggle Pixelshift Reset on Movement"
 	set category = "Pixelshift"
 
-	if(!CONFIG_GET(/datum/config_entry/flag/pixelshift_toggle_allow))
+	if(!CONFIG_GET(flag/pixelshift_toggle_allow))
 		to_chat(src, span_warning("This feature is disabled via config."))
 		return
 

--- a/talestation_modules/code/modules/mob/pixel_shift.dm
+++ b/talestation_modules/code/modules/mob/pixel_shift.dm
@@ -1,6 +1,7 @@
 /// -- Pixelshifting UI and component. --
 /// Keybinding hotkey signal.
 #define COMSIG_KB_MOVEMENT_PIXELSHIFT_DOWN "keybinding_movement_pixelshift_down"
+#define COMSIG_KB_MOVEMENT_PIXELSHIFT_TOGGLE_DOWN "keybinding_movement_pixelshift_toggle_down"
 #define COMSIG_KB_MOVEMENT_PIXELSHIFT_RESET_DOWN "keybinding_movement_pixelshift_reset_down"
 
 /// Defines for mins and maxs of x and y shifts.

--- a/talestation_modules/code/modules/mob/pixel_shift.dm
+++ b/talestation_modules/code/modules/mob/pixel_shift.dm
@@ -26,7 +26,7 @@
 	return ..()
 
 /mob/living/Initialize(mapload)
-	RegisterSignal(src, SIGNAL_ADDTRAIT(TRAIT_RESTRAINED), .proc/reset_pixelshift)
+	RegisterSignal(src, SIGNAL_ADDTRAIT(TRAIT_RESTRAINED), .verb/reset_pixelshift)
 	return ..()
 
 /mob/living/Destroy()
@@ -51,10 +51,6 @@
 	. = ..()
 	if(!allow_pixelshifting())
 		reset_pixelshift()
-
-/mob/living/_add_trait(datum/thing, trait, source)
-	. = ..()
-
 
 /mob/living/verb/reset_pixelshift()
 	set name = "Reset Pixelshift"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Revamps how pixel shifting works to not need a dedicated UI for it.
The UI will still exist but is removed entirely codewise.

Also adds a toggle to not have pixelshifting reset when you move, makes it easier to keep your position for stuff like say, piggyback riding.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How does it improve TaleStation

QOL.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Pixelshifting no longer requires an entire dedicated UI
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
