### PR TITLE
Fixes the loadout's Bomber Jacket's item_path to give the actual bomber jacket

### DIFF
--- a/talestation_modules/code/modules/loadouts/loadout_items/loadout_datum_suits.dm
+++ b/talestation_modules/code/modules/loadouts/loadout_items/loadout_datum_suits.dm
@@ -91,7 +91,7 @@ GLOBAL_LIST_INIT(loadout_exosuits, generate_loadout_items(/datum/loadout_item/su
 
 /datum/loadout_item/suit/bomber_jacket
 	name = "Bomber Jacket"
-	item_path = /obj/item/clothing/suit/jacket
+	item_path = /obj/item/clothing/suit/jacket/bomber
 
 /datum/loadout_item/suit/military_jacket
 	name = "Military Jacket"


### PR DESCRIPTION
## About The Pull Request
Can't play my static without their signature jacket.

I fixed this for Skyrat already, so I know that's the proper fix (so yes technically it's tested, even if it's a webedit).

## How does it improve TaleStation
Working loadout items are nice, less debug items in circulation.

## Changelog

:cl: GoldenAlpharex
fix: Fixes the bomber jacket in the loadout not actually giving you the bomber jacket.
/:cl: