### PR TITLE
adds 4 different TG PRs

### DIFF
--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -254,9 +254,10 @@ GLOBAL_LIST_INIT(ai_employers, list(
 /// If the objective is no longer valid
 #define OBJECTIVE_STATE_INVALID 5
 
-/// Weights for traitor objective categories
-#define OBJECTIVE_WEIGHT_TINY    5
-#define OBJECTIVE_WEIGHT_SMALL 	 7
+#define OBJECTIVE_WEIGHT_TINY 5
+#define OBJECTIVE_WEIGHT_SMALL 7
 #define OBJECTIVE_WEIGHT_DEFAULT 10
-#define OBJECTIVE_WEIGHT_BIG	 15
-#define OBJECTIVE_WEIGHT_HUGE	 20
+#define OBJECTIVE_WEIGHT_BIG 15
+#define OBJECTIVE_WEIGHT_HUGE 20
+
+#define REVENANT_NAME_FILE "revenant_names.json"

--- a/code/__DEFINES/sight.dm
+++ b/code/__DEFINES/sight.dm
@@ -10,6 +10,8 @@
 //#define SEE_INVISIBLE_LEVEL_TWO 45 //currently unused
 //#define INVISIBILITY_LEVEL_TWO 45 //currently unused
 
+#define INVISIBILITY_REVENANT 50
+
 #define INVISIBILITY_OBSERVER 60
 #define SEE_INVISIBLE_OBSERVER 60
 

--- a/code/controllers/subsystem/ban_cache.dm
+++ b/code/controllers/subsystem/ban_cache.dm
@@ -19,17 +19,28 @@ SUBSYSTEM_DEF(ban_cache)
 		return
 	var/current_time = REALTIMEOFDAY
 	var/list/look_for = list()
+
+	var/list/query_args = list()
+	var/list/query_arg_keys = list()
+
+	var/num_keys = 0
 	for(var/ckey in GLOB.directory)
 		var/client/lad = GLOB.directory[ckey]
 		// If they've already got a ban cached, or a request goin, don't do it
 		if(lad.ban_cache || lad.ban_cache_start)
 			continue
+
 		look_for += ckey
 		lad.ban_cache_start = current_time
+
+		query_args += list("key[num_keys]" = ckey)
+		query_arg_keys += ":key[num_keys]"
+		num_keys++
+
 	// We're gonna try and make a query for clients
 	var/datum/db_query/query_batch_ban_cache = SSdbcore.NewQuery(
-		"SELECT ckey, role, applies_to_admins FROM [format_table_name("ban")] WHERE ckey IN (:ckeys) AND unbanned_datetime IS NULL AND (expiration_time IS NULL OR expiration_time > NOW())",
-		list("ckeys" = look_for.Join(","))
+		"SELECT ckey, role, applies_to_admins FROM [format_table_name("ban")] WHERE ckey IN ([query_arg_keys.Join(",")]) AND unbanned_datetime IS NULL AND (expiration_time IS NULL OR expiration_time > NOW())",
+		query_args
 	)
 
 	var/succeeded = query_batch_ban_cache.Execute()

--- a/code/datums/elements/haunted.dm
+++ b/code/datums/elements/haunted.dm
@@ -2,13 +2,17 @@
 /datum/element/haunted
 	element_flags = ELEMENT_DETACH
 
-/datum/element/haunted/Attach(datum/target)
+/datum/element/haunted/Attach(datum/target, haunt_color = "#f8f8ff")
 	. = ..()
 	if(!isitem(target))
-		return COMPONENT_INCOMPATIBLE
-	//Make em look spooky
+		return ELEMENT_INCOMPATIBLE
+
 	var/obj/item/master = target
-	master.add_filter("haunt_glow", 2, list("type" = "outline", "color" = "#f8f8ff", "size" = 1))
+	if(istype(master.ai_controller, /datum/ai_controller/haunted))
+		return ELEMENT_INCOMPATIBLE
+
+	//Make em look spooky
+	master.add_filter("haunt_glow", 2, list("type" = "outline", "color" = haunt_color, "size" = 1))
 	master.ai_controller = new /datum/ai_controller/haunted(master)
 	master.AddElement(/datum/element/movetype_handler)
 	ADD_TRAIT(master, TRAIT_MOVE_FLYING, ELEMENT_TRAIT(type))
@@ -21,5 +25,3 @@
 	REMOVE_TRAIT(master, TRAIT_MOVE_FLYING, ELEMENT_TRAIT(type))
 	master.RemoveElement(/datum/element/movetype_handler)
 	return ..()
-
-

--- a/code/game/machinery/gulag_teleporter.dm
+++ b/code/game/machinery/gulag_teleporter.dm
@@ -140,7 +140,6 @@ The console is located at computer/gulag_teleporter.dm
 					continue
 				if(linked_reclaimer)
 					linked_reclaimer.stored_items[mob_occupant] += W
-					linked_reclaimer.contents += W
 					W.forceMove(linked_reclaimer)
 				else
 					W.forceMove(src)

--- a/code/modules/admin/verbs/deadsay.dm
+++ b/code/modules/admin/verbs/deadsay.dm
@@ -25,14 +25,7 @@
 		rank_name = pick(strings("admin_nicknames.json", "ranks", "config"))
 		admin_name = pick(strings("admin_nicknames.json", "names", "config"))
 	var/name_and_rank = "[span_tooltip(rank_name, "STAFF")] ([admin_name])"
-	var/rendered = "<span class='game deadsay'>[span_prefix("DEAD:")] [name_and_rank] says, <span class='message'>\"[emoji_parse(msg)]\"</span></span>"
-
-	for (var/mob/M in GLOB.player_list)
-		var/admin_holder = M.client?.holder
-		if(isnewplayer(M) && !admin_holder) // We want to make sure admins can see this when in the lobby too!
-			continue
-		if (M.stat == DEAD || (admin_holder && (M.client?.prefs.chat_toggles & CHAT_DEAD))) //admins can toggle deadchat on and off. This is a proc in admin.dm and is only given to Administrators and above
-			to_chat(M, rendered, confidential = TRUE)
+	deadchat_broadcast("[span_prefix("DEAD:")] [name_and_rank] says, <span class='message'>\"[emoji_parse(msg)]\"</span>")
 
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Dsay") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 

--- a/code/modules/antagonists/revenant/haunted_item.dm
+++ b/code/modules/antagonists/revenant/haunted_item.dm
@@ -1,0 +1,100 @@
+/// Makes our item SUPER spooky!
+/// Adds the haunted element and some other bonuses
+/datum/component/haunted_item
+	/// Our throwforce before being haunted
+	var/pre_haunt_throwforce
+	/// Optional message displayed when we're despawned / dehaunted
+	var/despawn_message
+	/// List of types that, if they hit our item, we will instantly stop the haunting
+	var/list/types_which_dispell_us
+
+/datum/component/haunted_item/Initialize(
+	// What color should the haunted item be glowing? By default the color's white (passed into the haunted element).
+	haunt_color,
+	// How long should the haunt last? If null, it will last forever / until removed.
+	haunt_duration,
+	// How far should the haunted item look for targets when it's created? If null, it won't aggro anyone by default.
+	aggro_radius,
+	// Optional, what message should the item show when the haunt happens (when the component is applied)?
+	spawn_message,
+	// Optional, what message should the item show when the haunt ends (clear_haunting is called)?
+	despawn_message,
+	// How much throwforce does the haunted item get? Keep in mind it attacks by throwing itself
+	throw_force_bonus = 3,
+	// What's the max amount of throwforce that we should consider going to
+	throw_force_max = 15,
+	// See the types_which_dispell_us list. By default / if null, this will become the default static list.
+	list/types_which_dispell_us,
+)
+
+	if(!isitem(parent))
+		return COMPONENT_INCOMPATIBLE
+
+	var/obj/item/haunted_item = parent
+	if(istype(haunted_item.ai_controller, /datum/ai_controller/haunted)) // already spooky
+		return COMPONENT_INCOMPATIBLE
+
+	haunted_item.AddElement(/datum/element/haunted, haunt_color)
+	if(isnull(haunted_item.ai_controller)) // failed to make spooky! don't go on
+		return COMPONENT_INCOMPATIBLE
+
+	if(!isnull(haunt_duration))
+		addtimer(CALLBACK(src, .proc/clear_haunting), haunt_duration)
+
+	if(!isnull(spawn_message))
+		haunted_item.visible_message(spawn_message)
+
+	if(!isnull(aggro_radius))
+		// We were given an aggro radius, we'll start attacking people nearby
+		for(var/mob/living/victim in view(aggro_radius, haunted_item))
+			if(victim.stat != CONSCIOUS)
+				continue
+			if(victim.mob_biotypes & MOB_SPIRIT)
+				continue
+			if(victim.invisibility >= INVISIBILITY_REVENANT)
+				continue
+			// This gives all mobs in view "5" haunt level
+			// For reference picking one up gives "2"
+			haunted_item.ai_controller.blackboard[BB_TO_HAUNT_LIST][WEAKREF(victim)] = 5
+
+	if(haunted_item.throwforce < throw_force_max)
+		pre_haunt_throwforce = haunted_item.throwforce
+		haunted_item.throwforce = min(haunted_item.throwforce + throw_force_bonus, throw_force_max)
+
+	var/static/list/default_dispell_types = list(/obj/item/nullrod, /obj/item/storage/book/bible)
+	src.types_which_dispell_us = types_which_dispell_us || default_dispell_types
+	src.despawn_message = despawn_message
+
+/datum/component/haunted_item/Destroy(force, silent)
+	var/obj/item/haunted_item = parent
+	// Handle these two specifically in Destroy() instead of clear_haunting(),
+	// because we want to make sure they always get dealt with no matter how the component is removed
+	if(!isnull(pre_haunt_throwforce))
+		haunted_item.throwforce = pre_haunt_throwforce
+	haunted_item.RemoveElement(/datum/element/haunted)
+	return ..()
+
+/datum/component/haunted_item/RegisterWithParent()
+	RegisterSignal(parent, COMSIG_PARENT_ATTACKBY, .proc/on_hit_by_holy_tool)
+
+/datum/component/haunted_item/UnregisterFromParent()
+	UnregisterSignal(parent, COMSIG_PARENT_ATTACKBY)
+
+/// Removes the haunting, showing any despawn message we have and qdeling our component
+/datum/component/haunted_item/proc/clear_haunting()
+	var/obj/item/haunted_item = parent
+
+	if(!isnull(despawn_message))
+		haunted_item.visible_message(despawn_message)
+
+	qdel(src)
+
+/// Signal proc for [COMSIG_PARENT_ATTACKBY], when we get smacked by holy stuff we should stop being ghostly.
+/datum/component/haunted_item/proc/on_hit_by_holy_tool(obj/item/source, obj/item/attacking_item, mob/living/attacker, params)
+	SIGNAL_HANDLER
+
+	if(!is_type_in_list(attacking_item, types_which_dispell_us))
+		return
+
+	clear_haunting()
+	return COMPONENT_NO_AFTERATTACK

--- a/code/modules/antagonists/revenant/revenant.dm
+++ b/code/modules/antagonists/revenant/revenant.dm
@@ -3,9 +3,6 @@
 //Can hear deadchat, but are NOT normal ghosts and do NOT have x-ray vision
 //Admin-spawn or random event
 
-#define INVISIBILITY_REVENANT 50
-#define REVENANT_NAME_FILE "revenant_names.json"
-
 /mob/living/simple_animal/revenant
 	name = "revenant"
 	desc = "A malevolent spirit."
@@ -95,6 +92,9 @@
 
 	var/datum/action/cooldown/spell/aoe/revenant/malfunction/shuttle_go_emag = new(src)
 	shuttle_go_emag.Grant(src)
+
+	var/datum/action/cooldown/spell/aoe/revenant/haunt_object/toolbox_go_bonk = new(src)
+	toolbox_go_bonk.Grant(src)
 
 	RegisterSignal(src, COMSIG_LIVING_BANED, .proc/on_baned)
 	random_revenant_name()

--- a/code/modules/antagonists/revenant/revenant_abilities.dm
+++ b/code/modules/antagonists/revenant/revenant_abilities.dm
@@ -399,3 +399,55 @@
 		tray.set_pestlevel(rand(8, 10))
 		tray.set_weedlevel(rand(8, 10))
 		tray.set_toxic(rand(45, 55))
+
+
+/datum/action/cooldown/spell/aoe/revenant/haunt_object
+	name = "Haunt Object"
+	desc = "Empower nearby objects to you with ghostly energy, causing them to attack nearby mortals. \
+		Items closer to you are more likely to be haunted."
+	icon_icon = 'icons/mob/actions/actions_revenant.dmi'
+	button_icon_state = "r_haunt"
+	max_targets = 7
+	aoe_radius = 5
+
+	unlock_amount = 30 // Similar to overload lights
+	cast_amount = 50 // but has a longer lasting effect
+	stun_duration = 3 SECONDS
+	reveal_duration = 6 SECONDS
+
+/datum/action/cooldown/spell/aoe/revenant/haunt_object/get_things_to_cast_on(atom/center)
+	var/list/things = list()
+	for(var/obj/item/nearby_item in range(aoe_radius, center))
+		// Don't throw around anchored things or dense things
+		// (Or things not on a turf but I am not sure if range can catch that)
+		if(nearby_item.anchored || nearby_item.density || !isturf(nearby_item.loc))
+			continue
+		// Don't throw abstract things
+		if(nearby_item.item_flags & ABSTRACT)
+			continue
+		// Don't throw things we can't see
+		if(nearby_item.invisibility >= INVISIBILITY_REVENANT)
+			continue
+		// Don't throw things that are already throwing themself
+		if(istype(nearby_item.ai_controller, /datum/ai_controller/haunted))
+			continue
+
+		things += nearby_item
+
+	return things
+
+/datum/action/cooldown/spell/aoe/revenant/haunt_object/cast_on_thing_in_aoe(obj/item/victim, mob/living/simple_animal/revenant/caster)
+	var/distance_from_caster = get_dist(get_turf(victim), get_turf(caster))
+	var/chance_of_haunting = 150 * (1 / distance_from_caster)
+	if(!prob(chance_of_haunting))
+		return
+
+	new /obj/effect/temp_visual/revenant(get_turf(victim))
+
+	victim.AddComponent(/datum/component/haunted_item, \
+		haunt_color = "#823abb", \
+		haunt_duration = rand(1 MINUTES, 3 MINUTES), \
+		aggro_radius = aoe_radius - 1, \
+		spawn_message = span_revenwarning("[victim] begins to float and twirl into the air as it glows a ghastly purple!"), \
+		despawn_message = span_revenwarning("[victim] falls back to the ground, stationary once more."), \
+	)

--- a/code/modules/mod/mod_types.dm
+++ b/code/modules/mod/mod_types.dm
@@ -373,7 +373,7 @@
 		/obj/item/mod/module/stealth/ninja,
 		/obj/item/mod/module/quick_carry/advanced,
 		/obj/item/mod/module/magboot/advanced,
-		/obj/item/mod/module/jetpack,
+		/obj/item/mod/module/jetpack/advanced,
 		/obj/item/mod/module/anomaly_locked/kinesis/plus,
 	)
 

--- a/code/modules/mod/modules/module_kinesis.dm
+++ b/code/modules/mod/modules/module_kinesis.dm
@@ -138,6 +138,8 @@
 	COOLDOWN_START(src, hit_cooldown, hit_cooldown_time)
 
 /obj/item/mod/module/anomaly_locked/kinesis/proc/can_grab(atom/target)
+	if(mod.wearer == target)
+		return FALSE
 	if(!ismovable(target))
 		return FALSE
 	if(iseffect(target))

--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -25,6 +25,7 @@
 	var/datum/storage/modstorage = mod.create_storage(max_specific_storage = max_w_class, max_total_storage = max_combined_w_class, max_slots = max_items)
 	modstorage.set_real_location(src)
 	atom_storage.locked = FALSE
+	RegisterSignal(mod.chestplate, COMSIG_ITEM_PRE_UNEQUIP, .proc/on_chestplate_unequip)
 
 /obj/item/mod/module/storage/on_uninstall(deleting = FALSE)
 	var/datum/storage/modstorage = mod.atom_storage
@@ -38,7 +39,8 @@
 	if(QDELETED(source) || !mod.wearer || newloc == mod.wearer || !mod.wearer.s_store)
 		return
 	to_chat(mod.wearer, span_notice("[src] tries to store [mod.wearer.s_store] inside itself."))
-	atom_storage?.attempt_insert(mod.wearer.s_store, mod.wearer, override = TRUE)
+	if(atom_storage?.attempt_insert(mod.wearer.s_store, mod.wearer, override = TRUE))
+		mod.wearer.temporarilyRemoveItemFromInventory(mod.wearer.s_store)
 
 /obj/item/mod/module/storage/large_capacity
 	name = "MOD expanded storage module"

--- a/code/modules/spells/spell_types/aoe_spell/_aoe_spell.dm
+++ b/code/modules/spells/spell_types/aoe_spell/_aoe_spell.dm
@@ -7,17 +7,20 @@
 /datum/action/cooldown/spell/aoe
 	/// The max amount of targets we can affect via our AOE. 0 = unlimited
 	var/max_targets = 0
+	/// Should we shuffle the targets lift after getting them via get_things_to_cast_on?
+	var/shuffle_targets_list = FALSE
 	/// The radius of the aoe.
 	var/aoe_radius = 7
 
 // At this point, cast_on == owner. Either works.
+// Don't extend this for your spell! Look at cast_on_thing_in_aoe.
 /datum/action/cooldown/spell/aoe/cast(atom/cast_on)
 	. = ..()
 	// Get every atom around us to our aoe cast on
 	var/list/atom/things_to_cast_on = get_things_to_cast_on(cast_on)
-	// If we have a target limit, shuffle it (for fariness)
-	if(max_targets > 0)
-		things_to_cast_on = shuffle(things_to_cast_on)
+	// If set, shuffle the list of things we're going to cast on to remove any existing order
+	if(shuffle_targets_list)
+		shuffle_inplace(things_to_cast_on)
 
 	SEND_SIGNAL(src, COMSIG_SPELL_AOE_ON_CAST, things_to_cast_on, cast_on)
 
@@ -31,11 +34,21 @@
 		num_targets++
 
 /**
- * Gets a list of atoms around [center]
- * that are within range and affected by our aoe.
+ * Gets a list of atoms around [center] that are within range and going to be affected by our aoe.
+ * You should override this on a subtype basis to change what your spell affects.
+ *
+ * For example, if you want to only cast on atoms in view instead of range.
+ * Or, if you only want living mobs in the list.
+ *
+ * When using range / view, it's handy to remember the byond optimization they have by casting to an atom type.
+ *
+ * Returns a list of atoms.
  */
 /datum/action/cooldown/spell/aoe/proc/get_things_to_cast_on(atom/center)
+	RETURN_TYPE(/list)
+
 	var/list/things = list()
+	// Default behavior is to get all atoms in range, center and owner not included.
 	for(var/atom/nearby_thing in range(aoe_radius, center))
 		if(nearby_thing == owner || nearby_thing == center)
 			continue

--- a/code/modules/spells/spell_types/aoe_spell/magic_missile.dm
+++ b/code/modules/spells/spell_types/aoe_spell/magic_missile.dm
@@ -44,4 +44,5 @@
 	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC
 
 	max_targets = 6
+	shuffle_targets_list = TRUE
 	projectile_type = /obj/projectile/magic/aoe/magic_missile/lesser

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -263,6 +263,10 @@
 	. = ..()
 	UnregisterSignal(user, COMSIG_SURGERY_STARTING)
 
+/obj/item/surgical_processor/cyborg_unequip(mob/user)
+	. = ..()
+	UnregisterSignal(user, COMSIG_SURGERY_STARTING)
+
 /obj/item/surgical_processor/afterattack(atom/design_holder, mob/user, proximity)
 	if(!proximity)
 		return ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2319,6 +2319,7 @@
 #include "code\modules\antagonists\nukeop\equipment\nuclear_bomb\self_destruct.dm"
 #include "code\modules\antagonists\nukeop\equipment\nuclear_bomb\syndicate_nuke.dm"
 #include "code\modules\antagonists\pirate\pirate.dm"
+#include "code\modules\antagonists\revenant\haunted_item.dm"
 #include "code\modules\antagonists\revenant\revenant.dm"
 #include "code\modules\antagonists\revenant\revenant_abilities.dm"
 #include "code\modules\antagonists\revenant\revenant_antag.dm"


### PR DESCRIPTION
## About The Pull Request

https://github.com/tgstation/tgstation/pull/69593
https://github.com/tgstation/tgstation/pull/69348
https://github.com/tgstation/tgstation/pull/69618
https://github.com/tgstation/tgstation/pull/69703

## How does it improve TaleStation

it won't

## Changelog
🆑Ghommie, MrMelbert, Fikou, Timberpoes
fix: Brought a portion of the admin deadsay command up to date. Revenants and EOR players will now see admin deadchat messages in their chat tab.
add: Revenants have a new spell available. Haunt Object, it allows them to cause nearby loose items to lift off the ground and start attacking people! The objects will return to peace after a few minutes, or if someone dispels them with a null rod or bible.
add: Revenants have a new spell available. Haunt Object, it allows them to cause nearby loose items to lift off the ground and start attacking people! The objects will return to peace after a few minutes, or if someone dispels them with a null rod or bible.
fix: Fixes an SQL query so that role banned players are now correctly banned from their roles again.
/🆑
