### PR TITLE
Mirrors missed mirrrors 

### DIFF
--- a/code/datums/ruins/space.dm
+++ b/code/datums/ruins/space.dm
@@ -117,7 +117,7 @@
 	id = "derelict8"
 	suffix = "derelict8.dmm"
 	name = "Derelict 8"
-	description = "An auxillary storage bay might be the least respected room on any functional station, but studies show they are the least likely to be hit in an artillery strike."
+	description = "An auxiliary storage bay might be the least respected room on any functional station, but studies show they are the least likely to be hit in an artillery strike."
 
 /datum/map_template/ruin/space/empty_shell
 	id = "empty-shell"

--- a/code/game/area/areas/station.dm
+++ b/code/game/area/areas/station.dm
@@ -1370,7 +1370,7 @@
 
 // Useless room
 /area/station/science/auxlab
-	name = "\improper Auxillary Lab"
+	name = "\improper Auxiliary Lab"
 	icon_state = "aux_lab"
 
 /area/station/science/auxlab/firing_range

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -700,7 +700,7 @@
 					if(ratio>1)
 						ratio = 1
 						uses -= round(overall_damage)
-						H.visible_message(span_warning("[H] is fully healed by [H==user ? "[H.p_their()]":"[H]'s"]'s blood magic!"))
+						H.visible_message(span_warning("[H] is fully healed by [H==user ? "[H.p_their()]":"[H]'s"] blood magic!"))
 					else
 						H.visible_message(span_warning("[H] is partially healed by [H==user ? "[H.p_their()]":"[H]'s"] blood magic."))
 						uses = 0

--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -134,7 +134,7 @@ Runs the event
 		log_game("Random Event triggering: [name] ([typepath]).")
 
 	if(alert_observers)
-		deadchat_broadcast(" has just been[random ? " randomly" : ""] triggered!", "<b>[name]</b>.", message_type=DEADCHAT_ANNOUNCEMENT) //STOP ASSUMING IT'S BADMINS!
+		deadchat_broadcast(" has just been[random ? " randomly" : ""] triggered!", "<b>[name]</b>", message_type=DEADCHAT_ANNOUNCEMENT) //STOP ASSUMING IT'S BADMINS!
 
 	SSblackbox.record_feedback("tally", "event_ran", 1, "[E]")
 	return E

--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -185,18 +185,18 @@
 
 /obj/machinery/computer/shuttle/pirate
 	name = "pirate shuttle console"
-	shuttleId = "pirateship"
+	shuttleId = "pirate"
 	icon_screen = "syndishuttle"
 	icon_keyboard = "syndie_key"
 	light_color = COLOR_SOFT_RED
-	possible_destinations = "pirateship_away;pirateship_home;pirateship_custom"
+	possible_destinations = "pirate_away;pirate_home;pirate_custom"
 
 /obj/machinery/computer/camera_advanced/shuttle_docker/syndicate/pirate
 	name = "pirate shuttle navigation computer"
 	desc = "Used to designate a precise transit location for the pirate shuttle."
-	shuttleId = "pirateship"
+	shuttleId = "pirate"
 	lock_override = CAMERA_LOCK_STATION
-	shuttlePortId = "pirateship_custom"
+	shuttlePortId = "pirate_custom"
 	x_offset = 9
 	y_offset = 0
 	see_hidden = FALSE

--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -283,7 +283,8 @@ GLOBAL_LIST_EMPTY(gravity_generators)
 
 /obj/machinery/gravity_generator/main/power_change()
 	. = ..()
-	investigate_log("has [machine_stat & NOPOWER ? "lost" : "regained"] power.", INVESTIGATE_GRAVITY)
+	if(SSticker.current_state == GAME_STATE_PLAYING)
+		investigate_log("has [machine_stat & NOPOWER ? "lost" : "regained"] power.", INVESTIGATE_GRAVITY)
 	set_power()
 
 /obj/machinery/gravity_generator/main/get_status()
@@ -300,7 +301,8 @@ GLOBAL_LIST_EMPTY(gravity_generators)
 		new_state = TRUE
 
 	charging_state = new_state ? POWER_UP : POWER_DOWN // Startup sequence animation.
-	investigate_log("is now [charging_state == POWER_UP ? "charging" : "discharging"].", INVESTIGATE_GRAVITY)
+	if(SSticker.current_state == GAME_STATE_PLAYING)
+		investigate_log("is now [charging_state == POWER_UP ? "charging" : "discharging"].", INVESTIGATE_GRAVITY)
 	update_appearance()
 
 /obj/machinery/gravity_generator/main/proc/enable()
@@ -310,8 +312,9 @@ GLOBAL_LIST_EMPTY(gravity_generators)
 
 	soundloop.start()
 	if (!gravity_in_level())
-		investigate_log("was brought online and is now producing gravity for this level.", INVESTIGATE_GRAVITY)
-		message_admins("The gravity generator was brought online [ADMIN_VERBOSEJMP(src)]")
+		if(SSticker.current_state == GAME_STATE_PLAYING)
+			investigate_log("was brought online and is now producing gravity for this level.", INVESTIGATE_GRAVITY)
+			message_admins("The gravity generator was brought online [ADMIN_VERBOSEJMP(src)]")
 		shake_everyone()
 	gravity_field = new(src, 2, TRUE, 6)
 
@@ -325,8 +328,9 @@ GLOBAL_LIST_EMPTY(gravity_generators)
 	soundloop.stop()
 	QDEL_NULL(gravity_field)
 	if (gravity_in_level())
-		investigate_log("was brought offline and there is now no gravity for this level.", INVESTIGATE_GRAVITY)
-		message_admins("The gravity generator was brought offline with no backup generator. [ADMIN_VERBOSEJMP(src)]")
+		if(SSticker.current_state == GAME_STATE_PLAYING)
+			investigate_log("was brought offline and there is now no gravity for this level.", INVESTIGATE_GRAVITY)
+			message_admins("The gravity generator was brought offline with no backup generator. [ADMIN_VERBOSEJMP(src)]")
 		shake_everyone()
 
 	complete_state_update()

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -319,15 +319,23 @@
 
 	var/reagent_note
 	if(reagents?.reagent_list)
-		reagent_note = " REAGENTS:"
-		for(var/datum/reagent/R in reagents.reagent_list)
-			reagent_note += "[R.name] ([num2text(R.volume)])"
+		reagent_note = "REAGENTS: [pretty_string_from_reagent_list(reagents.reagent_list)]"
 
 	if(ismob(firer))
 		log_combat(firer, L, "shot", src, reagent_note)
-	else
-		L.log_message("has been shot by [firer] with [src]", LOG_ATTACK, color="orange")
+		return BULLET_ACT_HIT
 
+	if(isvehicle(firer))
+		var/obj/vehicle/firing_vehicle = firer
+
+		var/list/logging_mobs = firing_vehicle.return_controllers_with_flag(VEHICLE_CONTROL_EQUIPMENT)
+		if(!LAZYLEN(logging_mobs))
+			logging_mobs = firing_vehicle.return_drivers()
+		for(var/mob/logged_mob as anything in logging_mobs)
+			log_combat(logged_mob, L, "shot", src, "from inside [firing_vehicle][logging_mobs.len > 1 ? " with multiple occupants" : null][reagent_note ? " and contained [reagent_note]" : null]")
+		return BULLET_ACT_HIT
+
+	L.log_message("has been shot by [firer] with [src][reagent_note ? " containing [reagent_note]" : null]", LOG_VICTIM, color="orange", log_globally=FALSE)
 	return BULLET_ACT_HIT
 
 /obj/projectile/proc/vol_by_damage()
@@ -698,6 +706,7 @@
 		AddElement(/datum/element/embed, projectile_payload = shrapnel_type)
 	if(!log_override && firer && original)
 		log_combat(firer, original, "fired at", src, "from [get_area_name(src, TRUE)]")
+			//note: mecha projectile logging is handled in /obj/item/mecha_parts/mecha_equipment/weapon/action(). try to keep these messages roughly the sameish just for consistency's sake.
 	if(direct_target && (get_dist(direct_target, get_turf(src)) <= 1)) // point blank shots
 		process_hit(get_turf(direct_target), direct_target)
 		if(QDELETED(src))

--- a/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
+++ b/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
@@ -63,6 +63,7 @@
 				spread = round((i / projectiles_per_shot - 0.5) * variance)
 
 		var/obj/projectile/projectile_obj = new projectile(get_turf(src))
+		projectile_obj.log_override = TRUE //we log being fired ourselves a little further down.
 		projectile_obj.firer = chassis
 		projectile_obj.preparePixelProjectile(target, source, modifiers, spread)
 		if(source.client && isliving(source)) //dont want it to happen from syndie mecha npc mobs, they do direct fire anyways
@@ -73,11 +74,13 @@
 			new firing_effect_type(get_turf(src), chassis.dir)
 		playsound(chassis, fire_sound, 50, TRUE)
 
+		log_combat(source, target, "fired [projectile_obj] at", src, "from [chassis] at [get_area_name(src, TRUE)]")
+
 		sleep(max(0, projectile_delay))
 
 		if(kickback)
 			chassis.newtonian_move(newtonian_target)
-	chassis.log_message("Fired from [name], targeting [target].", LOG_ATTACK)
+	chassis.log_message("[key_name(source)] fired [src], targeting [target].", LOG_ATTACK)
 
 //Base energy weapon type
 /obj/item/mecha_parts/mecha_equipment/weapon/energy


### PR DESCRIPTION
Mirrors:

https://github.com/tgstation/tgstation/pull/69819
https://github.com/tgstation/tgstation/pull/69789
https://github.com/tgstation/tgstation/pull/69800
https://github.com/tgstation/tgstation/pull/69805
https://github.com/tgstation/tgstation/pull/69802
https://github.com/tgstation/tgstation/pull/69808 (only the code tho)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Rhials, Thunder12345, ShizCalev, JohnFulpWillard
spellcheck: Fixes a typo in the cult heal spell feedback message.
spellcheck: fixes some internal typos related to the word "auxillary".
fix: Purged pointless punctuation from probabalistic phenomenon publications
fix: Projectiles fired by non-mob sources (IE turrets) now log reagents contained after hitting a target.
admin: Cleaned up projectile reagent logging a little.
admin: Projectiles fired from mecha will now combat log on the target AND the firer.
admin: Mecha chassis logs will now contain the name/ckey of the person who fired the mecha's weapon.
admin: Projectiles fired from vehicles are now more likely to be combat logged properly after hitting a target (this logs for all people with control of the mecha which is a little messy with multi-seat mecha. Check the vehicle's logs or a user's combat logs for the person that actually SHOT the projectile.)
admin: Silenced grav generator admin warnings / logging messages when the round is not currently in progress.
fix: Pirate ships now work again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
