### PR TITLE
OOC mute no longer mutes LOOC

### DIFF
--- a/talestation_modules/code/modules/client/verbs/looc.dm
+++ b/talestation_modules/code/modules/client/verbs/looc.dm
@@ -18,9 +18,6 @@ GLOBAL_VAR_INIT(looc_allowed, TRUE)
 
 	// Run through some checks for non-admins
 	if(!holder)
-		if(!GLOB.ooc_allowed) // If OOC is disabled LOOC probably should be, too
-			to_chat(src, span_danger("All OOC is globally muted."))
-			return
 		if(!GLOB.looc_allowed)
 			to_chat(src, span_danger("LOOC is globally muted."))
 			return


### PR DESCRIPTION
This is fucking stupid.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Jolly
admin: Muting OOC as an admin no longer mutes LOOC.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
