### PR TITLE
[MIRRO] abductors can now use their batons (#71341)

### DIFF
--- a/code/game/objects/items/melee/baton.dm
+++ b/code/game/objects/items/melee/baton.dm
@@ -36,6 +36,8 @@
 	var/stun_animation = TRUE
 	/// Whether the stun attack is logged. Only relevant for abductor batons, which have different modes.
 	var/log_stun_attack = TRUE
+	/// Boolean on whether people with chunky fingers can use this baton.
+	var/chunky_finger_usable = FALSE
 
 	/// The context to show when the baton is active and targetting a living thing
 	var/context_living_target_active = "Stun"
@@ -120,7 +122,7 @@
 	if(clumsy_check(user, target))
 		return BATON_ATTACK_DONE
 
-	if(ishuman(user))
+	if(!chunky_finger_usable && ishuman(user))
 		var/mob/living/carbon/human/potential_chunky_finger_human = user
 		if(potential_chunky_finger_human.check_chunky_fingers() && user.is_holding(src))
 			balloon_alert(potential_chunky_finger_human, "fingers are too big!")

--- a/code/modules/antagonists/abductor/equipment/abduction_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_gear.dm
@@ -451,6 +451,7 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 	knockdown_time = 14 SECONDS
 	on_stun_sound = 'sound/weapons/egloves.ogg'
 	affect_cyborg = TRUE
+	chunky_finger_usable = TRUE
 
 	var/mode = BATON_STUN
 


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/71341

No one thought of this during the PR, so what's up Abductors have chunky fingers for some reason, further proving that species is a bad idea and the only playable mob should be pun pun.

Adds a 'chunky finger usable' var to let Abductor batons allow people with chunky fingers to use it.
## Changelog
:cl: JohnFulpWillard
fix: Abductors can now use their batons.
/:cl:
