### PR TITLE
Some Pubby Fixes

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -4103,6 +4103,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
 "aQI" = (
@@ -4116,6 +4117,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
 "aQJ" = (
@@ -4130,6 +4132,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
 "aQL" = (
@@ -4142,6 +4145,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
 "aQM" = (
@@ -4712,6 +4716,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/mail_sorting/service/hydroponics,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "aWU" = (
@@ -4869,6 +4874,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "aYf" = (
@@ -5290,6 +5296,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "bcA" = (
@@ -6425,6 +6432,7 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/door/firedoor,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "bod" = (
@@ -7111,8 +7119,7 @@
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "bzC" = (
-/obj/structure/table,
-/obj/effect/spawner/random/maintenance/two,
+/obj/structure/reagent_dispensers/plumbed,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/morgue)
 "bAd" = (
@@ -7187,6 +7194,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/morgue)
 "bBk" = (
@@ -8385,6 +8393,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"bPY" = (
+/obj/machinery/duct,
+/turf/open/floor/iron,
+/area/station/service/hydroponics)
 "bPZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/nitrous_output{
 	dir = 8
@@ -11392,6 +11404,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/any/medical/general,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "cML" = (
@@ -12112,14 +12125,13 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
 "deH" = (
-/obj/machinery/light/small/directional/east,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/chair/stool/bar/directional/west,
 /obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/morgue)
 "dfn" = (
@@ -12210,6 +12222,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "dgI" = (
@@ -12270,6 +12283,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "dif" = (
@@ -12607,6 +12621,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "drm" = (
@@ -13367,6 +13382,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/library)
+"dLN" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/medical/cryo)
 "dLQ" = (
 /obj/effect/turf_decal/bot_white/right,
 /obj/structure/cable,
@@ -14035,6 +14059,18 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
+"eae" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/duct,
+/turf/open/floor/plating,
+/area/station/maintenance/department/crew_quarters/bar)
 "eas" = (
 /obj/structure/chair,
 /obj/machinery/status_display/evac/directional/north,
@@ -14961,6 +14997,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "etg" = (
@@ -15155,6 +15192,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "eyj" = (
@@ -15852,6 +15890,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
+"eNQ" = (
+/obj/structure/reagent_dispensers/plumbed,
+/turf/open/floor/plating,
+/area/station/maintenance/department/crew_quarters/bar)
 "eOm" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -17709,6 +17751,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "fKT" = (
@@ -18183,9 +18226,6 @@
 /obj/structure/sign/directions/security{
 	dir = 1;
 	pixel_x = 32
-	},
-/obj/machinery/door/airlock/qm{
-	name = "Quartermaster"
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
@@ -19723,6 +19763,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "gFH" = (
@@ -20357,6 +20398,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "gUb" = (
@@ -20965,6 +21007,7 @@
 	},
 /obj/machinery/fax_machine/recieving_disabled,
 /obj/structure/table,
+/obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/service)
 "hky" = (
@@ -24646,6 +24689,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"iYP" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron,
+/area/station/service/hydroponics)
 "iYU" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/light/small/directional/north,
@@ -25487,6 +25541,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/medical/medbay/central)
 "jsV" = (
@@ -25982,6 +26037,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "jIk" = (
@@ -29057,6 +29113,17 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"lha" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron,
+/area/station/service/hydroponics)
 "lhe" = (
 /obj/machinery/firealarm/directional/east,
 /obj/machinery/door/firedoor,
@@ -31266,6 +31333,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/any/medical/general,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/morgue)
 "mgt" = (
@@ -32018,6 +32086,13 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/monastery)
+"mvp" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "mvs" = (
 /obj/item/food/meat/slab/monkey,
 /turf/open/floor/plating,
@@ -32128,7 +32203,7 @@
 /turf/open/floor/plating,
 /area/station/cargo/warehouse/upper)
 "myO" = (
-/obj/item/reagent_containers/cup/bucket,
+/obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "mzf" = (
@@ -32406,6 +32481,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "mEF" = (
@@ -33082,6 +33158,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "mYH" = (
@@ -33277,9 +33354,13 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/medical)
 "nde" = (
-/obj/structure/sink/directional/west,
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "ndr" = (
 /obj/structure/flora/bush/leavy/style_random,
 /obj/structure/flora/bush/reed/style_random,
@@ -33733,6 +33814,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "nmA" = (
@@ -34052,6 +34134,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/service/kitchen,
 /obj/effect/mapping_helpers/airlock/access/any/service/hydroponics,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/service/kitchen)
 "nwo" = (
@@ -35226,6 +35309,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "nVU" = (
@@ -36141,6 +36225,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "oqu" = (
@@ -37438,6 +37523,7 @@
 	name = "Hydroponics"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/service/hydroponics,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "oWb" = (
@@ -38458,6 +38544,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "pwM" = (
@@ -40689,6 +40776,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "qyW" = (
@@ -42040,6 +42128,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/any/service/kitchen,
+/obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/station/service/kitchen)
 "rfh" = (
@@ -42130,6 +42219,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "rhG" = (
@@ -42355,6 +42445,13 @@
 /obj/machinery/firealarm/directional/east,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
+/obj/item/reagent_containers/cup/watering_can{
+	pixel_x = 6;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/cup/watering_can{
+	pixel_y = 4
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "rnH" = (
@@ -42976,9 +43073,14 @@
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "ryQ" = (
-/obj/machinery/holopad,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/cafeteria,
+/area/station/service/kitchen)
 "ryU" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -43348,6 +43450,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "rJS" = (
@@ -44216,6 +44319,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "siK" = (
@@ -46070,6 +46174,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/service)
 "tdz" = (
@@ -46407,6 +46512,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "tkJ" = (
@@ -46931,6 +47037,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "twM" = (
@@ -47737,6 +47844,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "tRc" = (
@@ -49086,6 +49194,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "uxj" = (
@@ -49374,7 +49483,7 @@
 	dir = 4;
 	dwidth = 5;
 	height = 7;
-	shuttle_id = "supply_home";
+	shuttle_id = "cargo_home";
 	name = "Cargo Bay";
 	width = 12
 	},
@@ -51485,6 +51594,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/medical/medbay/central)
 "vBj" = (
@@ -52264,6 +52374,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "vWO" = (
@@ -52374,6 +52485,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 9
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/service)
 "vYf" = (
@@ -52817,6 +52929,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "wlc" = (
@@ -53488,6 +53601,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "wxP" = (
@@ -56188,6 +56302,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/hangover,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "xGL" = (
@@ -56570,6 +56685,7 @@
 /obj/structure/disposalpipe/junction{
 	dir = 8
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "xOx" = (
@@ -57558,6 +57674,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/any/service/hydroponics,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
 "ymh" = (
@@ -82884,12 +83001,12 @@ gXY
 dGS
 edO
 exQ
-qwO
+dLN
 jIg
 boa
-hsj
-hsj
-hsj
+nde
+nde
+nde
 pzf
 hsj
 eDd
@@ -83631,11 +83748,11 @@ nMS
 aQH
 ylX
 mYq
-nfw
+lha
 qeD
 aRL
 mDn
-myO
+aZW
 aZW
 vJR
 vAq
@@ -83654,7 +83771,7 @@ tgT
 mDN
 boB
 dYc
-wGJ
+mvp
 ppE
 eeM
 wIF
@@ -83888,7 +84005,7 @@ aPy
 aQI
 aKT
 jgb
-ftu
+iYP
 tnh
 aRL
 sqw
@@ -84145,7 +84262,7 @@ raP
 aQJ
 aKT
 uFb
-ftu
+iYP
 vXy
 aRL
 eOq
@@ -84398,8 +84515,8 @@ aKQ
 aKQ
 aKQ
 aKT
-aLL
-wbR
+eNQ
+eae
 aKT
 lOv
 rJF
@@ -84655,7 +84772,7 @@ aKQ
 aLE
 mJs
 aKT
-aLL
+eNQ
 aQL
 aKT
 vde
@@ -84663,7 +84780,7 @@ aZW
 aZW
 aRL
 keu
-aZW
+bPY
 uwY
 gTR
 aZW
@@ -85692,7 +85809,7 @@ iNR
 iNR
 afu
 tgo
-nde
+aZW
 wxO
 ykz
 bcd
@@ -86464,7 +86581,7 @@ bkU
 bkU
 oMX
 ezr
-ezr
+ryQ
 bbg
 jks
 jks
@@ -86721,7 +86838,7 @@ aVZ
 aWW
 afu
 bce
-ezr
+ryQ
 cpm
 bcg
 jMM
@@ -86978,7 +87095,7 @@ afu
 afu
 afu
 rxV
-ezr
+ryQ
 kKe
 tMy
 bdp
@@ -88020,7 +88137,7 @@ piY
 rIB
 cpZ
 cqc
-ryQ
+ufo
 ouM
 sjm
 xcz


### PR DESCRIPTION
Fixes: #3343, Fixes: #3344, Fixes: #3345, Fixes: #3347

## Changelog

:cl: Jolly
fix: There are no longer two holo pads in Pubbys medbay lobby.
fix: There is no longer a rogue airlock outside of security on Pubby.
fix: The cargo shuttle will now dock on Pubby.
qol: Watering cans were added to Pubby hydroponics.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
