### PR TITLE
I HATE BLUE SEC, The sec doors are now RED

### DIFF
--- a/talestation_modules/code/aesthetics_module/doors/airlock.dm
+++ b/talestation_modules/code/aesthetics_module/doors/airlock.dm
@@ -174,7 +174,7 @@
 	icon = 'talestation_modules/icons/obj/doors/airlocks/station/command.dmi'
 
 /obj/machinery/door/airlock/security
-	icon = 'talestation_modules/icons/obj/doors/airlocks/station/security.dmi'
+	icon = 'talestation_modules/icons/obj/doors/airlocks/station/security2.dmi'
 
 /obj/machinery/door/airlock/security/old
 	icon = 'talestation_modules/icons/obj/doors/airlocks/station/security2.dmi'


### PR DESCRIPTION
I HATE BLUE SEC I HATE BLUE SEC I HATE BLUE SEC.
Yell at me the next time I just PORT SHIT HAPHAZARDLY.

## Changelog

:cl: Jolly
qol: The sec doors on all maps should now just be RED. As GOD intended them TO BE.
/:cl:
