### PR TITLE
Bandaid fix for missing command intercom sprites

### DIFF
--- a/talestation_modules/code/aesthetics_module/icon_overrides/items/misc.dm
+++ b/talestation_modules/code/aesthetics_module/icon_overrides/items/misc.dm
@@ -21,6 +21,9 @@
 /obj/item/radio/intercom
 	icon = 'talestation_modules/icons/obj/intercom.dmi'
 
+/obj/item/radio/intercom/command
+	icon_state = "intercom"
+
 /obj/item/wallframe/intercom
 	icon = 'talestation_modules/icons/obj/intercom.dmi'
 


### PR DESCRIPTION
I'm lazy.

## Changelog
:cl: Jolly
fix: Command intercoms should now be visible.
/:cl:
