### PR TITLE
Removes some old code

### DIFF
--- a/talestation_modules/code/hydroponics_module/defines/hydroponics.dm
+++ b/talestation_modules/code/hydroponics_module/defines/hydroponics.dm
@@ -1,5 +1,4 @@
 // -- Hydroponics tray additions --
-#define TRAY_MODIFIED_BASE_NUTRIDRAIN 0.5
 
 /obj/machinery/hydroponics
 	//Determines if we want to accept alien seeds
@@ -11,19 +10,6 @@
 	accepts_alien_seeds = TRUE
 	icon_state = "hydrotray2"
 
-/obj/machinery/hydroponics/constructable
-	// Nutriment drain is halved so they can not worry about fertilizer as much
-	nutridrain = TRAY_MODIFIED_BASE_NUTRIDRAIN
-
-/obj/machinery/hydroponics/set_self_sustaining(new_value)
-	var/old_self_sustaining = self_sustaining
-	. = ..()
-	if(self_sustaining != old_self_sustaining)
-		if(self_sustaining)
-			nutridrain /= 2
-		else
-			nutridrain *= 2
-
 /obj/machinery/hydroponics/constructable/RefreshParts()
 	. = ..()
 	// Dehardcodes the nutridrain scaling factor
@@ -31,4 +17,3 @@
 	// Adds a flat 100 max water (doesn't really matter cause autogrow)
 	maxwater += 100
 
-#undef TRAY_MODIFIED_BASE_NUTRIDRAIN


### PR DESCRIPTION
Yeah this, isn't really needed anymore. Trying to get away from what TaleStation used to be (a private server for a bunch of friends).

## Changelog
:cl: Jolly
del: Hydroponic trays no longer have a halved nutriment drain rate. 
/:cl:
