### PR TITLE
Changes the names to be improper of a few items 

### DIFF
--- a/talestation_modules/code/clothing_module/digi_clothing.dm
+++ b/talestation_modules/code/clothing_module/digi_clothing.dm
@@ -5,6 +5,7 @@
 	//Icon file for mob worn overlays, if the user is digitigrade.
 	var/icon/worn_icon_digitigrade
 	var/greyscale_config_worn_digitigrade
+
 /obj/item/clothing/under
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION
 

--- a/talestation_modules/code/clothing_module/neck/coconut_bra.dm
+++ b/talestation_modules/code/clothing_module/neck/coconut_bra.dm
@@ -1,7 +1,7 @@
 //Beach Episode item
 /obj/item/clothing/neck/cocobruh
 	name = "coconut bra"
-	desc = "You've seen these in those cheesy Space Films with Space Hawaiians. The coconuts are fake, don't even think about biting them.
+	desc = "You've seen these in those cheesy Space Films with Space Hawaiians. The coconuts are fake, don't even think about biting them."
 	icon = 'talestation_modules/icons/mob/clothing/eventitems.dmi'
 	icon_state = "cocobra"
 	worn_icon = 'talestation_modules/icons/mob/clothing/eventitems.dmi'

--- a/talestation_modules/code/clothing_module/neck/coconut_bra.dm
+++ b/talestation_modules/code/clothing_module/neck/coconut_bra.dm
@@ -1,8 +1,7 @@
 //Beach Episode item
 /obj/item/clothing/neck/cocobruh
-	name = "Coconut Bra"
-	desc = "You've seen these in those cheesy Space Films with Space Hawaiians. The coconuts are false, don't even think about biting them. \
-	Smells oddly of wax."
+	name = "coconut bra"
+	desc = "You've seen these in those cheesy Space Films with Space Hawaiians. The coconuts are fake, don't even think about biting them.
 	icon = 'talestation_modules/icons/mob/clothing/eventitems.dmi'
 	icon_state = "cocobra"
 	worn_icon = 'talestation_modules/icons/mob/clothing/eventitems.dmi'

--- a/talestation_modules/code/clothing_module/suits/duck_tube.dm
+++ b/talestation_modules/code/clothing_module/suits/duck_tube.dm
@@ -1,7 +1,7 @@
 //Beach Episode item
 // Sprite ported from baystation.
 /obj/item/clothing/suit/duck_tube
-	name = "Ducking Innertube"
+	name = "ducking innertube"
 	desc = "You got a sinking feeling you'll be perfectly fine."
 	icon = 'talestation_modules/icons/mob/clothing/eventitems.dmi'
 	icon_state = "inflatable"

--- a/talestation_modules/code/clothing_module/suits/grass_skirt.dm
+++ b/talestation_modules/code/clothing_module/suits/grass_skirt.dm
@@ -1,6 +1,6 @@
 //Beach Episode item
 /obj/item/clothing/suit/grasskirt
-	name = "Grass Skirt"
+	name = "grass skirt"
 	desc = "You're a real crowd killer! No, seriously."
 	icon = 'talestation_modules/icons/mob/clothing/eventitems.dmi'
 	icon_state = "gskirt"


### PR DESCRIPTION
@Fikou pointed this out to me when I was porting the flower garlands, been meaning to hit a few items here that I remembered.

## Changelog
:cl: Jolly
spellcheck: Three items had their names de-proper-itized. Instead of being "Blue Towel", for example, its now "blue towel".
/:cl:
