### PR TITLE
Fixes goliath hood icon

### DIFF
--- a/talestation_modules/code/clothing_module/suits/loadout_suits.dm
+++ b/talestation_modules/code/clothing_module/suits/loadout_suits.dm
@@ -9,6 +9,8 @@
 
 /obj/item/clothing/head/hooded/cloakhood/goliath_heirloom
 	name = "heirloom goliath cloak hood"
+	icon = 'icons/obj/clothing/head/helmet.dmi'
+	icon_state = "golhood"
 	desc = "A snug hood made out of materials from goliaths and watchers. This hood is quite worn and offers very little protection now."
 	clothing_flags = SNUG_FIT
 	flags_inv = HIDEEARS|HIDEEYES|HIDEHAIR|HIDEFACIALHAIR


### PR DESCRIPTION
Got deleted in #3679, fixed it. ♥

(For some reason it was using suits.dmi instead of a... head related one.)

:cl: ShizCalev
fix: The heirloom goliath cloak hood now has an icon again!
/:cl:
