### PR TITLE
Fixes the Mentions of Propionic Acid in the Pain Paper

### DIFF
--- a/talestation_modules/code/chemistry_module/reagents/pain_reagents.dm
+++ b/talestation_modules/code/chemistry_module/reagents/pain_reagents.dm
@@ -298,8 +298,8 @@
 	results = list(/datum/reagent/propionic_acid = 3)
 	required_reagents = list(/datum/reagent/carbon = 1, /datum/reagent/oxygen = 1, /datum/reagent/hydrogen = 1)
 	required_catalysts = list(/datum/reagent/toxin/acid = 1)
-	required_temp = 250
 	is_cold_recipe = TRUE
+	required_temp = 250
 	optimal_temp = 200
 	overheat_temp = 50
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_CHEMICAL

--- a/talestation_modules/code/chemistry_module/reagents/pain_reagents.dm
+++ b/talestation_modules/code/chemistry_module/reagents/pain_reagents.dm
@@ -298,8 +298,8 @@
 	results = list(/datum/reagent/propionic_acid = 3)
 	required_reagents = list(/datum/reagent/carbon = 1, /datum/reagent/oxygen = 1, /datum/reagent/hydrogen = 1)
 	required_catalysts = list(/datum/reagent/toxin/acid = 1)
-	is_cold_recipe = TRUE
 	required_temp = 250
+	is_cold_recipe = TRUE
 	optimal_temp = 200
 	overheat_temp = 50
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_CHEMICAL

--- a/talestation_modules/code/medical_module/medical_doctor/equipment.dm
+++ b/talestation_modules/code/medical_module/medical_doctor/equipment.dm
@@ -9,7 +9,9 @@
 						Simple!<br><br>The most common way is to use pain killers. Don't know how to make them? They're easy!<br><br> \
 						<b>Recipies</B><br><br> Aspirin - 1u Salyclic Acid, Acetone and Oxygen. Don't forget your catalyst of Sulfuric Acid! (1u). \
 						<br><br>Paracetamol - 1u Phenol, Acetone, Hydrogen, Oxygen and Nitric Acid.<br><br>Ibuprofen - 1u Propionic Acid, Phenol, Oyxgen and Hydrogen. \
-						<br><br>To make Propinoic Acid you will need 1u Carbon, Oxygen and Hydrogen. This is a key component don't forget it!<br><br> \
+						<br><br>To make Propinoic Acid you will need 1u Carbon, Oxygen and Hydrogen and your catalyst of Sulfuric Acid. \
+						You'll need to heat this up to about 225 K. \
+						This is a key component don't forget it!<br><br> \
 						<b>Other Notes</b><br><br>Miners may be a concern, but they're fortunate enough to have a skillchip to mitigate pain on them! \
 						When they're not on the station, of course.<br><br>If you have any further questions, don't hesitate to contact the head of your ward."
 


### PR DESCRIPTION
fixes: #3968

## Changelog

:cl: Jolly
fix: The pain papers all Medical staff spawn with now properly explain Propionic Acid creation.
/:cl:
