### PR TITLE
Balances out some of the random events

### DIFF
--- a/talestation_modules/code/events_module/random_events/tg_events.dm
+++ b/talestation_modules/code/events_module/random_events/tg_events.dm
@@ -1,0 +1,21 @@
+/datum/round_event_control/fake_virus
+	weight = 0
+	min_players = 10
+
+/datum/round_event_control/brain_trauma
+	weight = 5
+	min_players = 10
+
+/datum/round_event_control/bureaucratic_error
+	weight = 0
+	min_players = 10
+
+/datum/round_event_control/grey_tide
+	max_occurrences = 1
+
+/datum/round_event_control/ion_storm
+	min_players = 20
+
+/datum/round_event_control/shuttle_catastrophe
+	weight = 0
+	min_players = 10

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5121,6 +5121,7 @@
 #include "talestation_modules\code\clothing_module\under\jobs\rnd.dm"
 #include "talestation_modules\code\clothing_module\under\jobs\security.dm"
 #include "talestation_modules\code\emotes_module\pain_emotes.dm"
+#include "talestation_modules\code\events_module\random_events\tg_events.dm"
 #include "talestation_modules\code\events_module\resource_drift\crates.dm"
 #include "talestation_modules\code\events_module\resource_drift\resource_drift.dm"
 #include "talestation_modules\code\events_module\resource_drift\resource_pods.dm"


### PR DESCRIPTION
We've agreed some of these events just suck and add nothing to the small rounds.

## Changelog
:cl: Jolly
balance: Fake Virus, Brain Trauma, Bureaucratic Error, Grey Tide, Ion Storm and Shuttle Catastrophe will no longer spawn on lower pops. Their occurrences should also be almost non-existent, but still has a small (tiny, TINY) chance to occur.
/:cl:
