### PR TITLE
Reflects the auto transfer times to the repo as they are (now correctly) on the box

### DIFF
--- a/config/config.txt
+++ b/config/config.txt
@@ -652,10 +652,10 @@ TOAST_NOTIFICATION_ON_INIT
 TRANSFER_AUTO_VOTE_ENABLED
 
 ## minimum shift length allowed before transfer votes are enabled. Also when auto transfer votes begin, if enabled. (default 54000 = 1.5 hours)
-TRANSFER_TIME_MIN_ALLOWED 5400
+TRANSFER_TIME_MIN_ALLOWED 54000
 
 ## amount of time between automatic transfer votes. (default 18000 = 30 minutes)
-TRANSFER_TIME_BETWEEN_AUTO_VOTES 1800
+TRANSFER_TIME_BETWEEN_AUTO_VOTES 18000
 
 ## Server tagline: This will appear right below the server's title.
 # SERVERTAGLINE A generic TG-based server


### PR DESCRIPTION
Oops.
Fixes: #4065