### PR TITLE
Cleans up wall mounts and Issues

### DIFF
--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -145807,7 +145807,7 @@ vqC
 pDG
 iFZ
 gkr
-eCt
+ugR
 mmf
 dsH
 gVQ

--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -10322,7 +10322,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/control_center)
 "elU" = (
-/obj/structure/cable,
 /obj/item/clothing/gloves/color/yellow,
 /obj/item/storage/belt/utility,
 /obj/structure/closet/toolcloset,
@@ -22545,6 +22544,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
+"iQD" = (
+/obj/structure/cable,
+/turf/closed/wall/r_wall,
+/area/station/engineering/engine_smes)
 "iRs" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -31422,6 +31425,7 @@
 /obj/item/radio/intercom/directional/south,
 /obj/structure/tank_dispenser,
 /obj/machinery/light/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "mdQ" = (
@@ -31700,6 +31704,7 @@
 /obj/effect/turf_decal/tile/yellow/opposingcorners{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "miD" = (
@@ -36481,6 +36486,7 @@
 /area/station/science/lab)
 "nUy" = (
 /obj/machinery/vending/tool,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_half{
 	dir = 1
 	},
@@ -38626,6 +38632,10 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
+"oKc" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/engineering/storage)
 "oKl" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
@@ -41850,7 +41860,6 @@
 "pUC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/light/directional/north,
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/stripes/box,
@@ -45314,7 +45323,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "rgW" = (
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "rgZ" = (
@@ -54830,6 +54838,7 @@
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "uIP" = (
@@ -57789,7 +57798,6 @@
 /obj/machinery/suit_storage_unit/engine,
 /obj/machinery/firealarm/directional/south,
 /obj/effect/turf_decal/delivery/red,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "vSv" = (
@@ -57901,7 +57909,6 @@
 /obj/item/radio/intercom/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/vending/wardrobe/engi_wardrobe,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
@@ -62962,7 +62969,6 @@
 /obj/item/stack/sheet/plasteel{
 	amount = 10
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage)
 "xSs" = (
@@ -145801,7 +145807,7 @@ vqC
 pDG
 iFZ
 gkr
-ugR
+eCt
 mmf
 dsH
 gVQ
@@ -147344,7 +147350,7 @@ mKw
 oXY
 dya
 pUC
-tEf
+dQv
 tEf
 dQv
 elS
@@ -147601,7 +147607,7 @@ eHE
 dya
 dya
 vUe
-qQp
+oKc
 wDI
 dTe
 gOW
@@ -147858,7 +147864,7 @@ dxq
 dxq
 xcW
 hkH
-qQp
+oKc
 fPC
 dTk
 fQi
@@ -150425,7 +150431,7 @@ xZx
 xZx
 xZx
 xZx
-xZx
+iQD
 xZx
 acs
 eyY

--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -80,6 +80,8 @@
 /obj/structure/table,
 /obj/item/electronics/airlock,
 /obj/item/electronics/airlock,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "acw" = (
@@ -748,8 +750,8 @@
 /obj/structure/sign/poster/official/random/directional/east,
 /obj/effect/spawner/random/engineering/tool,
 /obj/effect/spawner/random/engineering/tool{
-	pixel_y = 5;
-	pixel_x = 5
+	pixel_x = 5;
+	pixel_y = 5
 	},
 /turf/open/floor/plating,
 /area/station/commons/vacant_room)
@@ -1157,11 +1159,6 @@
 "azS" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
-/obj/machinery/camera{
-	c_tag = "Engineering - Supermatter - Port";
-	dir = 8;
-	network = list("ss13","engine","sm")
-	},
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
@@ -1234,8 +1231,8 @@
 "aBO" = (
 /obj/machinery/light/small/directional/south,
 /obj/machinery/light_switch/directional/south{
-	pixel_y = -22;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = -22
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
@@ -1652,12 +1649,12 @@
 	pixel_y = 26
 	},
 /obj/machinery/button/ignition/incinerator/ordmix{
-	pixel_y = 26;
-	pixel_x = 10
+	pixel_x = 10;
+	pixel_y = 26
 	},
 /obj/machinery/button/door/incinerator_vent_ordmix{
-	pixel_y = -26;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = -26
 	},
 /turf/open/floor/engine,
 /area/station/science/ordnance/burnchamber)
@@ -3130,8 +3127,8 @@
 	dir = 8
 	},
 /obj/machinery/light_switch/directional/west{
-	pixel_y = 10;
-	pixel_x = -20
+	pixel_x = -20;
+	pixel_y = 10
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
@@ -3497,8 +3494,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/machinery/light_switch/directional/east{
-	pixel_y = 10;
-	pixel_x = 22
+	pixel_x = 22;
+	pixel_y = 10
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
@@ -3620,8 +3617,8 @@
 	dir = 1
 	},
 /obj/machinery/light_switch/directional/south{
-	pixel_y = -22;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = -22
 	},
 /turf/open/floor/wood,
 /area/station/service/library)
@@ -4568,11 +4565,11 @@
 "bRU" = (
 /obj/machinery/requests_console{
 	announcementConsole = 1;
+	anon_tips_receiver = 1;
+	assistance_requestable = 1;
 	department = "Captain's Desk";
 	name = "Captain RC";
-	pixel_y = 30;
-	assistance_requestable = 1;
-	anon_tips_receiver = 1
+	pixel_y = 30
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/wood{
@@ -4821,8 +4818,8 @@
 /area/station/tcommsat/server)
 "bZd" = (
 /obj/docking_port/stationary/random{
-	shuttle_id = "pod_lavaland2";
-	name = "lavaland"
+	name = "lavaland";
+	shuttle_id = "pod_lavaland2"
 	},
 /turf/open/space/openspace,
 /area/space)
@@ -5993,10 +5990,10 @@
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/requests_console/directional/north{
 	announcementConsole = 1;
-	department = "Bridge Officer's Desk";
-	name = "Bride Officer's RC";
+	anon_tips_receiver = 1;
 	assistance_requestable = 1;
-	anon_tips_receiver = 1
+	department = "Bridge Officer's Desk";
+	name = "Bride Officer's RC"
 	},
 /obj/structure/filingcabinet,
 /turf/open/floor/iron/dark,
@@ -6188,8 +6185,8 @@
 	dir = 6
 	},
 /obj/machinery/light_switch/directional/south{
-	pixel_y = -22;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = -22
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
@@ -6221,8 +6218,8 @@
 /obj/item/storage/fancy/candle_box,
 /obj/item/storage/fancy/candle_box,
 /obj/machinery/light_switch/directional/south{
-	pixel_y = -22;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = -22
 	},
 /turf/open/floor/iron/sepia,
 /area/station/service/chapel/funeral)
@@ -6369,8 +6366,8 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light_switch/directional/east{
-	pixel_y = 10;
-	pixel_x = 22
+	pixel_x = 22;
+	pixel_y = 10
 	},
 /turf/open/floor/iron,
 /area/station/commons/storage/art)
@@ -7060,8 +7057,8 @@
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /obj/machinery/light_switch/directional/west{
-	pixel_y = 10;
-	pixel_x = -20
+	pixel_x = -20;
+	pixel_y = 10
 	},
 /turf/open/floor/iron,
 /area/station/science/robotics/abandoned)
@@ -7632,8 +7629,8 @@
 /area/station/cargo/storage)
 "dfM" = (
 /obj/machinery/light_switch/directional/west{
-	pixel_y = 10;
-	pixel_x = -20
+	pixel_x = -20;
+	pixel_y = 10
 	},
 /turf/open/floor/wood,
 /area/station/commons/vacant_room/office)
@@ -7727,8 +7724,8 @@
 	dir = 10
 	},
 /obj/machinery/light_switch/directional/south{
-	pixel_y = -22;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = -22
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
@@ -8503,6 +8500,7 @@
 /obj/machinery/computer/monitor{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
 "dxA" = (
@@ -8512,8 +8510,8 @@
 "dxE" = (
 /obj/machinery/camera{
 	c_tag = "Security - Escape Pod";
-	network = list("ss13","prison");
-	dir = 1
+	dir = 1;
+	network = list("ss13","prison")
 	},
 /turf/open/floor/plating,
 /area/station/security/brig/upper)
@@ -8632,6 +8630,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "dyW" = (
@@ -8666,8 +8665,8 @@
 	dir = 1
 	},
 /obj/machinery/light_switch/directional/south{
-	pixel_y = -22;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = -22
 	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
@@ -9584,9 +9583,15 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "dTz" = (
-/obj/machinery/firealarm/directional/south,
 /obj/machinery/vending/tool,
 /obj/effect/turf_decal/bot,
+/obj/machinery/requests_console{
+	assistance_requestable = 1;
+	department = "Engineering";
+	name = "Engineering RC";
+	pixel_x = 32;
+	supplies_requestable = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage)
 "dTC" = (
@@ -10103,8 +10108,8 @@
 /obj/docking_port/stationary{
 	dwidth = 2;
 	height = 13;
-	shuttle_id = "ferry_home";
 	name = "port bay 2";
+	shuttle_id = "ferry_home";
 	width = 5
 	},
 /turf/open/space/openspace,
@@ -10832,6 +10837,14 @@
 /obj/structure/sign/poster/official/safety_internals{
 	pixel_x = -32
 	},
+/obj/machinery/requests_console{
+	assistance_requestable = 1;
+	department = "Atmospherics";
+	name = "Atmos RC";
+	pixel_x = -32;
+	pixel_y = 30;
+	supplies_requestable = 1
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/engineering/atmos/control_center)
 "ewO" = (
@@ -11171,8 +11184,8 @@
 /area/station/command/heads_quarters/captain)
 "eCG" = (
 /obj/machinery/light_switch/directional/east{
-	pixel_y = 10;
-	pixel_x = 22
+	pixel_x = 22;
+	pixel_y = 10
 	},
 /turf/open/floor/wood,
 /area/station/command/corporate_showroom)
@@ -11367,7 +11380,7 @@
 /turf/open/floor/wood,
 /area/station/service/bar)
 "eGA" = (
-/obj/item/radio/intercom/directional/north,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/showroomfloor,
 /area/station/engineering/atmos/control_center)
 "eGC" = (
@@ -11864,8 +11877,8 @@
 "eOL" = (
 /obj/structure/table/wood,
 /obj/machinery/light_switch/directional/south{
-	pixel_y = -22;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = -22
 	},
 /obj/machinery/camera{
 	c_tag = "Service - Library Backroom"
@@ -12211,13 +12224,8 @@
 /area/station/hallway/secondary/entry)
 "eVA" = (
 /obj/machinery/vending/wardrobe/atmos_wardrobe,
-/obj/machinery/requests_console{
-	department = "Atmospherics";
-	name = "Atmos RC";
-	pixel_y = 30;
-	assistance_requestable = 1;
-	supplies_requestable = 1
-	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/station/engineering/atmos/control_center)
 "eVD" = (
@@ -12246,11 +12254,11 @@
 "eVX" = (
 /obj/machinery/requests_console{
 	announcementConsole = 1;
+	anon_tips_receiver = 1;
+	assistance_requestable = 1;
 	department = "Head of Personnel's Desk";
 	name = "Head of Personnel RC";
-	pixel_y = -30;
-	assistance_requestable = 1;
-	anon_tips_receiver = 1
+	pixel_y = -30
 	},
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/wood,
@@ -12320,8 +12328,8 @@
 	dir = 6
 	},
 /obj/machinery/light_switch/directional/east{
-	pixel_y = 10;
-	pixel_x = 22
+	pixel_x = 22;
+	pixel_y = 10
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
@@ -12852,6 +12860,7 @@
 "fha" = (
 /obj/machinery/fax_machine,
 /obj/structure/table/reinforced,
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/dark/smooth_half{
 	dir = 1
 	},
@@ -12864,8 +12873,8 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/machinery/light_switch/directional/west{
-	pixel_y = 10;
-	pixel_x = -20
+	pixel_x = -20;
+	pixel_y = 10
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
@@ -12911,8 +12920,8 @@
 "fio" = (
 /obj/structure/reagent_dispensers/cooking_oil,
 /obj/machinery/light_switch/directional/south{
-	pixel_y = -22;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = -22
 	},
 /turf/open/floor/iron/freezer,
 /area/station/service/kitchen/coldroom)
@@ -13288,12 +13297,13 @@
 /obj/structure/closet/secure_closet/atmospherics,
 /obj/item/grenade/chem_grenade/smart_metal_foam,
 /obj/item/grenade/chem_grenade/smart_metal_foam,
-/obj/machinery/firealarm/directional/west,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/showroomfloor,
 /area/station/engineering/atmos/control_center)
 "fpz" = (
-/turf/open/floor/iron/showroomfloor,
-/area/station/engineering/atmos/control_center)
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/iron,
+/area/station/engineering/atmos/hfr_room)
 "fpD" = (
 /obj/effect/spawner/random/trash/moisture_trap,
 /turf/open/floor/plating,
@@ -13521,8 +13531,8 @@
 	network = list("ss13","prison")
 	},
 /obj/machinery/light_switch/directional/south{
-	pixel_y = -22;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = -22
 	},
 /turf/open/floor/iron/dark/side{
 	dir = 8
@@ -13542,8 +13552,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/assistant,
 /obj/machinery/light_switch/directional/west{
-	pixel_y = 10;
-	pixel_x = -20
+	pixel_x = -20;
+	pixel_y = 10
 	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
@@ -13657,9 +13667,9 @@
 	dir = 4;
 	dwidth = 3;
 	height = 5;
-	shuttle_id = "mining_home";
 	name = "mining shuttle bay";
 	roundstart_template = /datum/map_template/shuttle/mining/lima;
+	shuttle_id = "mining_home";
 	width = 7
 	},
 /turf/open/space/openspace,
@@ -13934,7 +13944,6 @@
 	amount = 25
 	},
 /obj/item/stack/sheet/iron/fifty,
-/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/showroomfloor,
 /area/station/engineering/atmos/control_center)
 "fAD" = (
@@ -14437,8 +14446,8 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/machinery/light_switch/directional/west{
-	pixel_y = 10;
-	pixel_x = -20
+	pixel_x = -20;
+	pixel_y = 10
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/aft)
@@ -15046,19 +15055,19 @@
 /obj/effect/turf_decal/tile/yellow/opposingcorners{
 	dir = 1
 	},
-/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/upper)
 "fWC" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Central";
+	dir = 1;
 	network = list("ss13","engine");
-	view_range = 10;
-	dir = 1
+	view_range = 10
 	},
 /obj/effect/turf_decal/tile/yellow/opposingcorners{
 	dir = 1
 	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/upper)
 "fWM" = (
@@ -15456,6 +15465,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/prison)
+"ghw" = (
+/obj/effect/turf_decal/tile/yellow/opposingcorners{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc/highcap/ten_k/directional/north,
+/turf/open/floor/iron,
+/area/station/engineering/atmos/upper)
 "ghA" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -16895,8 +16912,8 @@
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/effect/landmark/start/research_director,
 /obj/machinery/light_switch/directional/west{
-	pixel_y = 10;
-	pixel_x = -20
+	pixel_x = -20;
+	pixel_y = 10
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
@@ -17049,6 +17066,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/service/hydroponics,
 /obj/effect/mapping_helpers/airlock/access/any/service/hydroponics,
 /obj/effect/landmark/navigate_destination/kitchen,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/service/kitchen)
 "gMl" = (
@@ -17809,11 +17827,9 @@
 /turf/open/floor/iron,
 /area/station/science/cytology)
 "gXT" = (
-/obj/machinery/shower/directional/north,
-/obj/effect/turf_decal/stripes/box,
-/obj/item/radio/intercom/directional/south,
-/turf/open/floor/iron/dark/textured_large,
-/area/station/engineering/main)
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron,
+/area/station/engineering/atmos/hfr_room)
 "gYj" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/structure/cable,
@@ -17867,7 +17883,6 @@
 /area/station/engineering/atmos/upper)
 "hai" = (
 /obj/machinery/light/small/directional/south,
-/obj/item/radio/intercom/directional/south,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -18372,8 +18387,8 @@
 /obj/structure/training_machine,
 /obj/item/target,
 /obj/machinery/light_switch/directional/east{
-	pixel_y = 10;
-	pixel_x = 22
+	pixel_x = 22;
+	pixel_y = 10
 	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
@@ -18759,12 +18774,12 @@
 "hsW" = (
 /obj/machinery/requests_console{
 	announcementConsole = 1;
+	anon_tips_receiver = 1;
+	assistance_requestable = 1;
 	department = "Research Director's Desk";
 	name = "Research Director RC";
 	pixel_x = 30;
-	receive_ore_updates = 1;
-	assistance_requestable = 1;
-	anon_tips_receiver = 1
+	receive_ore_updates = 1
 	},
 /obj/machinery/modular_computer/console/preset/id{
 	dir = 8
@@ -18881,8 +18896,8 @@
 	dir = 8
 	},
 /obj/machinery/light_switch/directional/west{
-	pixel_y = 10;
-	pixel_x = -20
+	pixel_x = -20;
+	pixel_y = 10
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
@@ -18987,11 +19002,11 @@
 "hwI" = (
 /obj/machinery/requests_console{
 	announcementConsole = 1;
+	anon_tips_receiver = 1;
+	assistance_requestable = 1;
 	department = "Chief Medical Officer's Desk";
 	name = "Chief Medical Officer RC";
-	pixel_y = 30;
-	assistance_requestable = 1;
-	anon_tips_receiver = 1
+	pixel_y = 30
 	},
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
@@ -19029,10 +19044,10 @@
 "hxo" = (
 /obj/structure/cable,
 /obj/machinery/requests_console{
+	assistance_requestable = 1;
 	department = "Medical";
 	name = "Medbay RC";
-	pixel_y = -30;
-	assistance_requestable = 1
+	pixel_y = -30
 	},
 /obj/machinery/duct,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -19070,8 +19085,8 @@
 "hxZ" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/light_switch/directional/south{
-	pixel_y = -22;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = -22
 	},
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
@@ -19540,8 +19555,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light_switch/directional/west{
-	pixel_y = 10;
-	pixel_x = -20
+	pixel_x = -20;
+	pixel_y = 10
 	},
 /turf/open/floor/wood,
 /area/station/medical/psychology)
@@ -19784,8 +19799,6 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/control_center)
 "hLW" = (
@@ -20035,7 +20048,6 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/power/apc/highcap/ten_k/directional/north,
 /obj/machinery/light_switch/directional/north{
 	pixel_x = -11
 	},
@@ -20287,9 +20299,9 @@
 	dir = 8;
 	dwidth = 4;
 	height = 9;
-	shuttle_id = "aux_base_zone";
 	name = "aux base zone";
 	roundstart_template = /datum/map_template/shuttle/aux_base/default;
+	shuttle_id = "aux_base_zone";
 	width = 9
 	},
 /turf/open/floor/plating,
@@ -20322,11 +20334,11 @@
 /obj/item/assembly/flash/handheld,
 /obj/structure/cable,
 /obj/machinery/requests_console{
+	anon_tips_receiver = 1;
+	assistance_requestable = 1;
 	department = "Security";
 	name = "Security RC";
-	pixel_x = 32;
-	assistance_requestable = 1;
-	anon_tips_receiver = 1
+	pixel_x = 32
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/office)
@@ -22281,11 +22293,11 @@
 "iNE" = (
 /obj/machinery/requests_console{
 	announcementConsole = 1;
+	anon_tips_receiver = 1;
+	assistance_requestable = 1;
 	department = "Telecomms Admin";
 	name = "Telecomms RC";
-	pixel_y = 30;
-	assistance_requestable = 1;
-	anon_tips_receiver = 1
+	pixel_y = 30
 	},
 /obj/machinery/newscaster/directional/west,
 /obj/structure/closet/emcloset,
@@ -22386,8 +22398,8 @@
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
 /obj/machinery/light_switch/directional/south{
-	pixel_y = -22;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = -22
 	},
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
@@ -24155,6 +24167,19 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"jxl" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/effect/turf_decal/tile/yellow/opposingcorners{
+	dir = 1
+	},
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/iron,
+/area/station/engineering/atmos/upper)
 "jxm" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/white/filled/line{
@@ -24483,8 +24508,8 @@
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
 /obj/machinery/light_switch/directional/east{
-	pixel_y = 10;
-	pixel_x = 22
+	pixel_x = 22;
+	pixel_y = 10
 	},
 /turf/open/floor/iron,
 /area/station/command/gateway)
@@ -24864,11 +24889,11 @@
 "jKW" = (
 /obj/structure/cable,
 /obj/machinery/requests_console{
+	anon_tips_receiver = 1;
+	assistance_requestable = 1;
 	department = "Security";
 	name = "Security RC";
-	pixel_y = 30;
-	assistance_requestable = 1;
-	anon_tips_receiver = 1
+	pixel_y = 30
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -25147,7 +25172,6 @@
 /turf/open/floor/wood,
 /area/station/commons/dorms)
 "jRz" = (
-/obj/item/radio/intercom/directional/west,
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
@@ -25675,11 +25699,11 @@
 "kai" = (
 /obj/machinery/requests_console{
 	announcementConsole = 1;
+	anon_tips_receiver = 1;
+	assistance_requestable = 1;
 	department = "Head of Security's Desk";
 	name = "Head of Security RC";
-	pixel_y = 30;
-	assistance_requestable = 1;
-	anon_tips_receiver = 1
+	pixel_y = 30
 	},
 /obj/machinery/pdapainter/security,
 /turf/open/floor/wood,
@@ -25820,11 +25844,11 @@
 /area/station/holodeck/rec_center)
 "kbN" = (
 /obj/machinery/requests_console{
+	anon_tips_receiver = 1;
+	assistance_requestable = 1;
 	department = "Security";
 	name = "Security RC";
-	pixel_y = 30;
-	assistance_requestable = 1;
-	anon_tips_receiver = 1
+	pixel_y = 30
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -26297,10 +26321,10 @@
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/requests_console{
+	assistance_requestable = 1;
 	department = "Janitorial";
 	name = "Janitorial RC";
-	pixel_x = -30;
-	assistance_requestable = 1
+	pixel_x = -30
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/janitor)
@@ -26437,8 +26461,8 @@
 	dir = 8;
 	dwidth = 11;
 	height = 18;
-	shuttle_id = "whiteship_home";
 	name = "SS13: Auxiliary Dock, Station-Fore";
+	shuttle_id = "whiteship_home";
 	width = 36
 	},
 /turf/open/space/openspace,
@@ -26899,6 +26923,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/service/hydroponics,
 /obj/effect/mapping_helpers/airlock/access/any/service/hydroponics,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/service/kitchen)
 "kvY" = (
@@ -27712,8 +27737,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/hangover,
 /obj/machinery/light_switch/directional/east{
-	pixel_y = 10;
-	pixel_x = 22
+	pixel_x = 22;
+	pixel_y = 10
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/theater)
@@ -28920,11 +28945,11 @@
 /obj/machinery/firealarm/directional/south,
 /obj/machinery/requests_console{
 	announcementConsole = 1;
+	anon_tips_receiver = 1;
+	assistance_requestable = 1;
 	department = "Warden's Desk";
 	name = "Warden's RC";
-	pixel_x = 32;
-	assistance_requestable = 1;
-	anon_tips_receiver = 1
+	pixel_x = 32
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
@@ -28946,8 +28971,8 @@
 	dir = 8;
 	dwidth = 11;
 	height = 18;
-	shuttle_id = "whiteship_home";
 	name = "SS13: Auxiliary Dock, Station-Lower";
+	shuttle_id = "whiteship_home";
 	width = 30
 	},
 /turf/open/space/basic,
@@ -29205,10 +29230,10 @@
 /area/station/science/cytology)
 "lmT" = (
 /obj/machinery/requests_console{
+	assistance_requestable = 1;
 	department = "Engineering";
 	name = "Engineering RC";
 	pixel_y = -30;
-	assistance_requestable = 1;
 	supplies_requestable = 1
 	},
 /obj/machinery/modular_computer/console/preset/cargochat/engineering{
@@ -30172,10 +30197,10 @@
 	},
 /obj/machinery/requests_console{
 	announcementConsole = 1;
+	anon_tips_receiver = 1;
 	department = "Chief Engineer's Desk";
 	name = "Chief Engineer RC";
-	pixel_y = 30;
-	anon_tips_receiver = 1
+	pixel_y = 30
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
@@ -30228,9 +30253,9 @@
 /obj/docking_port/stationary{
 	dwidth = 3;
 	height = 15;
-	shuttle_id = "arrival_stationary";
 	name = "arrivals";
 	roundstart_template = /datum/map_template/shuttle/arrival/box;
+	shuttle_id = "arrival_stationary";
 	width = 7
 	},
 /turf/open/space/openspace,
@@ -30689,8 +30714,8 @@
 /area/station/command/heads_quarters/ce)
 "lOM" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	piping_layer = 2;
-	dir = 1
+	dir = 1;
+	piping_layer = 2
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
@@ -30890,10 +30915,10 @@
 	dir = 8
 	},
 /obj/machinery/requests_console{
+	assistance_requestable = 1;
 	department = "Medical";
 	name = "Medbay RC";
-	pixel_y = -30;
-	assistance_requestable = 1
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
@@ -31576,8 +31601,8 @@
 /obj/effect/spawner/random/food_or_drink/donkpockets,
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /obj/machinery/light_switch/directional/west{
-	pixel_y = 10;
-	pixel_x = -20
+	pixel_x = -20;
+	pixel_y = 10
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/break_room)
@@ -32045,11 +32070,11 @@
 /area/station/hallway/primary/central)
 "moz" = (
 /obj/machinery/requests_console{
+	anon_tips_receiver = 1;
+	assistance_requestable = 1;
 	department = "AI";
 	pixel_x = 30;
-	pixel_y = -30;
-	assistance_requestable = 1;
-	anon_tips_receiver = 1
+	pixel_y = -30
 	},
 /obj/machinery/flasher{
 	id = "AI";
@@ -32299,6 +32324,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "mtv" = (
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/storage)
 "mtx" = (
@@ -33674,10 +33700,10 @@
 	},
 /obj/item/retractor,
 /obj/machinery/requests_console{
+	assistance_requestable = 1;
 	department = "Medical";
 	name = "Medbay RC";
-	pixel_y = -30;
-	assistance_requestable = 1
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
@@ -33775,8 +33801,8 @@
 	pixel_y = -4
 	},
 /obj/item/ai_module/core/full/asimov{
-	pixel_y = 9;
-	pixel_x = 7
+	pixel_x = 7;
+	pixel_y = 9
 	},
 /obj/item/ai_module/reset{
 	pixel_x = 7
@@ -34604,8 +34630,8 @@
 "nmq" = (
 /obj/machinery/camera{
 	c_tag = "Science - Xenobiology Central Upper";
-	network = list("ss13","rd");
-	dir = 1
+	dir = 1;
+	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
@@ -35217,8 +35243,8 @@
 /obj/structure/table,
 /obj/machinery/light/small/directional/south,
 /obj/machinery/light_switch/directional/south{
-	pixel_y = -22;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = -22
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/disposal)
@@ -38028,9 +38054,9 @@
 	dir = 8;
 	dwidth = 2;
 	height = 5;
-	shuttle_id = "laborcamp_home";
 	name = "fore bay 1";
 	roundstart_template = /datum/map_template/shuttle/labour/lima;
+	shuttle_id = "laborcamp_home";
 	width = 9
 	},
 /turf/open/space/openspace,
@@ -38337,11 +38363,6 @@
 /obj/item/stock_parts/subspace/analyzer,
 /obj/item/stock_parts/subspace/analyzer,
 /obj/item/stock_parts/subspace/analyzer,
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/machinery/light_switch/directional/north{
-	pixel_x = -11
-	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "oEC" = (
@@ -38929,6 +38950,7 @@
 /obj/structure/closet/emcloset{
 	anchored = 1
 	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/textured_corner,
 /area/station/engineering/gravity_generator)
 "oQW" = (
@@ -39506,8 +39528,8 @@
 /obj/machinery/duct,
 /obj/machinery/camera{
 	c_tag = "Engineering - Airlock";
-	network = list("ss13","engine");
-	dir = 8
+	dir = 8;
+	network = list("ss13","engine")
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -39649,10 +39671,10 @@
 /area/station/hallway/secondary/command)
 "pdT" = (
 /obj/machinery/requests_console{
+	assistance_requestable = 1;
 	department = "Medical";
 	name = "Medbay RC";
-	pixel_y = -30;
-	assistance_requestable = 1
+	pixel_y = -30
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
@@ -39893,9 +39915,9 @@
 	dir = 2;
 	dwidth = 3;
 	height = 5;
-	shuttle_id = "commonmining_home";
 	name = "SS13: Common Mining Dock";
 	roundstart_template = /datum/map_template/shuttle/mining_common/meta;
+	shuttle_id = "commonmining_home";
 	width = 7
 	},
 /turf/open/floor/plating,
@@ -40107,8 +40129,8 @@
 	dir = 2;
 	dwidth = 14;
 	height = 17;
-	shuttle_id = "emergency_home";
 	name = "LimaStation emergency evac bay";
+	shuttle_id = "emergency_home";
 	width = 35
 	},
 /turf/open/space/openspace,
@@ -40213,8 +40235,8 @@
 "ppH" = (
 /obj/docking_port/stationary/random{
 	dir = 4;
-	shuttle_id = "pod_lavaland4";
-	name = "lavaland"
+	name = "lavaland";
+	shuttle_id = "pod_lavaland4"
 	},
 /turf/open/space/openspace,
 /area/space)
@@ -40554,8 +40576,8 @@
 "pwj" = (
 /obj/machinery/suit_storage_unit/hos,
 /obj/machinery/light_switch/directional/south{
-	pixel_y = -22;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = -22
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
@@ -41833,13 +41855,6 @@
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/stripes/box,
 /obj/structure/disposalpipe/trunk,
-/obj/machinery/requests_console{
-	department = "Engineering";
-	name = "Engineering RC";
-	pixel_y = 30;
-	assistance_requestable = 1;
-	supplies_requestable = 1
-	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage)
 "pUK" = (
@@ -41849,8 +41864,8 @@
 	dir = 8
 	},
 /obj/machinery/light_switch/directional/west{
-	pixel_y = 10;
-	pixel_x = -20
+	pixel_x = -20;
+	pixel_y = 10
 	},
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 4
@@ -41866,8 +41881,8 @@
 	},
 /obj/machinery/portable_atmospherics/canister/anesthetic_mix,
 /obj/machinery/light_switch/directional/south{
-	pixel_y = -22;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = -22
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
@@ -43345,8 +43360,8 @@
 "qwW" = (
 /obj/structure/table,
 /obj/item/paper_bin{
-	pixel_y = 8;
-	pixel_x = 6
+	pixel_x = 6;
+	pixel_y = 8
 	},
 /obj/machinery/requests_console{
 	announcementConsole = 1;
@@ -44045,9 +44060,15 @@
 /turf/open/floor/engine,
 /area/station/science/explab)
 "qKf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Engineering - Supermatter - Port";
+	dir = 6;
+	network = list("ss13","engine","sm")
+	},
+/turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "qKw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -44812,10 +44833,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
 "qYq" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
+/obj/structure/cable,
+/turf/open/floor/iron/showroomfloor,
+/area/station/engineering/lobby)
 "qYG" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/starboard/lower)
@@ -47796,8 +47816,8 @@
 /obj/machinery/light/cold/directional/south,
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/light_switch/directional/south{
-	pixel_y = -22;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = -22
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
@@ -48213,8 +48233,8 @@
 /area/station/maintenance/port/lower)
 "sjY" = (
 /obj/docking_port/stationary/random{
-	shuttle_id = "pod_2_lavaland";
-	name = "lavaland"
+	name = "lavaland";
+	shuttle_id = "pod_2_lavaland"
 	},
 /turf/open/space/openspace,
 /area/space)
@@ -50482,6 +50502,7 @@
 /obj/item/stock_parts/subspace/amplifier,
 /obj/item/stock_parts/subspace/amplifier,
 /obj/machinery/status_display/evac/directional/west,
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "sXo" = (
@@ -50525,8 +50546,8 @@
 	pixel_x = 1
 	},
 /obj/machinery/light_switch/directional/west{
-	pixel_y = 10;
-	pixel_x = -20
+	pixel_x = -20;
+	pixel_y = 10
 	},
 /turf/open/floor/wood,
 /area/station/science/ordnance/office)
@@ -50572,7 +50593,6 @@
 	network = list("ss13","engine")
 	},
 /obj/structure/cable,
-/obj/item/radio/intercom/directional/north,
 /obj/effect/turf_decal/tile/yellow/opposingcorners{
 	dir = 1
 	},
@@ -51019,8 +51039,8 @@
 /area/station/maintenance/port)
 "tiG" = (
 /obj/machinery/computer/security/telescreen/vault{
-	pixel_x = -32;
-	dir = 4
+	dir = 4;
+	pixel_x = -32
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
@@ -52072,8 +52092,8 @@
 "tDm" = (
 /obj/docking_port/stationary/random{
 	dir = 8;
-	shuttle_id = "pod_lavaland1";
-	name = "lavaland"
+	name = "lavaland";
+	shuttle_id = "pod_lavaland1"
 	},
 /turf/open/space/openspace,
 /area/space)
@@ -52550,6 +52570,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
 "tNs" = (
@@ -52980,11 +53001,11 @@
 /obj/structure/table,
 /obj/machinery/requests_console{
 	announcementConsole = 1;
+	anon_tips_receiver = 1;
+	assistance_requestable = 1;
 	department = "Bridge";
 	name = "Bridge RC";
-	pixel_y = -30;
-	assistance_requestable = 1;
-	anon_tips_receiver = 1
+	pixel_y = -30
 	},
 /obj/item/storage/toolbox/mechanical{
 	pixel_x = -1;
@@ -53646,8 +53667,8 @@
 /obj/item/book/manual/wiki/experimentor,
 /obj/item/relic,
 /obj/machinery/light_switch/directional/south{
-	pixel_y = -22;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = -22
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/circuits)
@@ -56186,10 +56207,6 @@
 /obj/machinery/rnd/production/circuit_imprinter,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/machinery/light_switch/directional/west{
-	pixel_y = 10;
-	pixel_x = -20
-	},
 /turf/open/floor/iron/dark/smooth_half{
 	dir = 1
 	},
@@ -56676,8 +56693,8 @@
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /obj/machinery/light_switch/directional/west{
-	pixel_y = 10;
-	pixel_x = -20
+	pixel_x = -20;
+	pixel_y = 10
 	},
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
@@ -56813,8 +56830,8 @@
 /obj/structure/table,
 /obj/item/clipboard,
 /obj/item/analyzer{
-	pixel_y = 2;
-	pixel_x = 4
+	pixel_x = 4;
+	pixel_y = 2
 	},
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/wood,
@@ -56864,8 +56881,8 @@
 	dir = 4
 	},
 /obj/machinery/light_switch/directional/east{
-	pixel_y = 10;
-	pixel_x = 22
+	pixel_x = 22;
+	pixel_y = 10
 	},
 /turf/open/floor/wood,
 /area/station/command/bridge_officer_office)
@@ -57092,11 +57109,11 @@
 /area/station/maintenance/starboard/aft)
 "vCT" = (
 /obj/machinery/requests_console{
+	anon_tips_receiver = 1;
+	assistance_requestable = 1;
 	department = "Security";
 	name = "Security RC";
-	pixel_y = 30;
-	assistance_requestable = 1;
-	anon_tips_receiver = 1
+	pixel_y = 30
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -57299,8 +57316,8 @@
 	},
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/light_switch/directional/south{
-	pixel_y = -22;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = -22
 	},
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 1
@@ -57351,7 +57368,6 @@
 	dir = 5;
 	network = list("ss13","engine")
 	},
-/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
 "vIX" = (
@@ -57360,7 +57376,6 @@
 /area/station/engineering/atmos/upper)
 "vIZ" = (
 /obj/machinery/light/directional/south,
-/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
 "vJh" = (
@@ -57547,8 +57562,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
 /obj/machinery/light_switch/directional/west{
-	pixel_y = 10;
-	pixel_x = -20
+	pixel_x = -20;
+	pixel_y = 10
 	},
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet)
@@ -58014,8 +58029,8 @@
 /area/station/security/brig/upper)
 "vXC" = (
 /obj/machinery/light_switch/directional/east{
-	pixel_y = 10;
-	pixel_x = 22
+	pixel_x = 22;
+	pixel_y = 10
 	},
 /turf/open/floor/iron/sepia,
 /area/station/service/chapel/office)
@@ -58310,8 +58325,8 @@
 	},
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/light_switch/directional/west{
-	pixel_y = 10;
-	pixel_x = -20
+	pixel_x = -20;
+	pixel_y = 10
 	},
 /turf/open/floor/iron,
 /area/station/science/ordnance/testlab)
@@ -58410,8 +58425,8 @@
 	network = list("ss13","rd")
 	},
 /obj/machinery/light_switch/directional/south{
-	pixel_y = -22;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = -22
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/robotics/lab)
@@ -58762,8 +58777,8 @@
 	name = "Cell Window Control";
 	pixel_x = -6;
 	pixel_y = 7;
-	specialfunctions = 4;
-	req_access = list("armory")
+	req_access = list("armory");
+	specialfunctions = 4
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -59114,8 +59129,8 @@
 "wrC" = (
 /obj/structure/table,
 /obj/item/stamp{
-	pixel_y = 6;
-	pixel_x = 10
+	pixel_x = 10;
+	pixel_y = 6
 	},
 /obj/item/stamp/denied{
 	pixel_x = 10
@@ -61241,8 +61256,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/firealarm/directional/south,
 /obj/machinery/light_switch/directional/south{
-	pixel_y = -22;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = -22
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/command/heads_quarters/cmo)
@@ -61719,8 +61734,8 @@
 /obj/structure/table,
 /obj/effect/spawner/random/engineering/tool,
 /obj/effect/spawner/random/engineering/tool{
-	pixel_y = 5;
-	pixel_x = 5
+	pixel_x = 5;
+	pixel_y = 5
 	},
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/starboard/lower)
@@ -62452,8 +62467,8 @@
 /obj/machinery/computer/cargo/request,
 /obj/machinery/camera{
 	c_tag = "Cargo - Lobby";
-	network = list("ss13","qm");
-	dir = 1
+	dir = 1;
+	network = list("ss13","qm")
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 9
@@ -62722,8 +62737,8 @@
 	dir = 8;
 	dwidth = 4;
 	height = 7;
-	shuttle_id = "cargo_home";
 	name = "Cargo Bay";
+	shuttle_id = "cargo_home";
 	width = 10
 	},
 /turf/open/space/openspace,
@@ -80272,7 +80287,7 @@ uLv
 vSv
 vSv
 vSv
-vSv
+fpz
 fJL
 fJL
 wcl
@@ -82328,7 +82343,7 @@ uLv
 vSv
 vSv
 vSv
-vSv
+gXT
 fJL
 fJL
 ymg
@@ -143467,7 +143482,7 @@ jlN
 lnK
 eCt
 lBx
-eCt
+qKf
 ejk
 eCt
 ksF
@@ -143723,13 +143738,13 @@ eOi
 tSS
 hyr
 iKs
-qKf
+iKs
 dXj
 ell
 wMu
 ell
 dXj
-qYq
+eoE
 eoE
 eOi
 tTG
@@ -146565,7 +146580,7 @@ gOW
 eFH
 pkL
 fef
-fpz
+fFn
 fFn
 fRm
 eeX
@@ -146825,7 +146840,7 @@ sig
 ftF
 hLQ
 gOW
-eeX
+ghw
 alF
 oIu
 oIu
@@ -149890,7 +149905,7 @@ gMz
 fXe
 mqo
 hMU
-gXT
+bJI
 xZx
 qYc
 rzN
@@ -150676,7 +150691,7 @@ aZj
 mna
 fQi
 sYW
-wwF
+jxl
 fQi
 cDL
 sqS
@@ -151180,7 +151195,7 @@ jGV
 jSA
 jSA
 cPM
-kqt
+qYq
 uLe
 hLy
 jnn
@@ -151437,7 +151452,7 @@ jGV
 xSw
 xSw
 unO
-kqt
+qYq
 dxw
 jGV
 oYJ


### PR DESCRIPTION
Jolly asked that I take a look at the issue tracker and fix some issues. I've also taken the liberty to de-obfuscate as many wall-mounts in engineering as I could. Most things are on their own walls where logically possible. All APC's should be on their own walls now, since this is the only thing that actually mechanically matters. If the rest of the station is like this, then I can understand why an issue was made for it. It's bad. 
Also cleans out the following Issues:
closes #4726
closes #4727

partially addresses  #4150
I wouldn't go calling it a culling, but actually spreading things out to a reasonable degree. I moved some request consoles away from desks with this, because those are mounts that I can actually shove in corners. 


## Changelog
:cl:
fix: A cleanup pass on Limastation mostly concentrated around engineering - For now. 
/:cl: