### PR TITLE
Removes headshots pref options, temporarily

### DIFF
--- a/talestation_modules/code/flavor_module/examine_tgui.dm
+++ b/talestation_modules/code/flavor_module/examine_tgui.dm
@@ -51,31 +51,25 @@
 	var/datum/preferences/preferences = holder.client?.prefs
 
 	var/flavor_text
-	var/custom_species
-	var/custom_species_lore
 	var/obscured
 	var/ooc_notes = ""
-	var/headshot = ""
+	//var/headshot = ""
 
 	// Now we handle silicon and/or human, order doesn't really matter
 	// If other variants of mob/living need to be handled at some point, put them here
 	if(issilicon(holder))
 		flavor_text = preferences.read_preference(/datum/preference/text/silicon_flavor_text)
-		custom_species = "Silicon"
-		custom_species_lore = "A cyborg unit."
 		ooc_notes += preferences.read_preference(/datum/preference/text/ooc_notes)
-		headshot += preferences.read_preference(/datum/preference/text/headshot)
+		//headshot += preferences.read_preference(/datum/preference/text/headshot)
 
 	if(ishuman(holder))
 		var/mob/living/carbon/human/holder_human = holder
 		obscured = (holder_human.wear_mask && (holder_human.wear_mask.flags_inv & HIDEFACE)) || (holder_human.head && (holder_human.head.flags_inv & HIDEFACE))
-		custom_species = obscured ? "Obscured" : holder_human.dna.features["custom_species"]
 		flavor_text = obscured ? "Obscured" :  holder_human.dna.features["flavor_text"]
-		custom_species_lore = obscured ? "Obscured" : holder_human.dna.features["custom_species_lore"]
 		ooc_notes += holder_human.dna.features["ooc_notes"]
-		if(!obscured)
+		/*if(!obscured)
 			headshot += holder_human.dna.features["headshot"]
-
+*/
 	var/name = obscured ? "Unknown" : holder.name
 
 	data["obscured"] = obscured ? TRUE : FALSE
@@ -83,7 +77,5 @@
 	data["assigned_map"] = examine_panel_screen.assigned_map
 	data["flavor_text"] = flavor_text
 	data["ooc_notes"] = ooc_notes
-	data["custom_species"] = custom_species
-	data["custom_species_lore"] = custom_species_lore
-	data["headshot"] = headshot
+	// data["headshot"] = headshot
 	return data

--- a/talestation_modules/code/flavor_module/flavor_text.dm
+++ b/talestation_modules/code/flavor_module/flavor_text.dm
@@ -209,19 +209,3 @@ GLOBAL_LIST_EMPTY(flavor_texts)
 
 /datum/preference/text/ooc_notes/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
 	target.dna.features["ooc_notes"] = value
-
-/datum/preference/text/custom_species
-	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL
-	savefile_identifier = PREFERENCE_CHARACTER
-	savefile_key = "custom_species"
-
-/datum/preference/text/custom_species/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
-	target.dna.features["custom_species"] = value
-
-/datum/preference/text/custom_species_lore
-	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL
-	savefile_identifier = PREFERENCE_CHARACTER
-	savefile_key = "custom_species_lore"
-
-/datum/preference/text/custom_species_lore/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
-	target.dna.features["custom_species_lore"] = value

--- a/talestation_modules/code/prefs_module/headshot.dm
+++ b/talestation_modules/code/prefs_module/headshot.dm
@@ -3,6 +3,7 @@
 #define LENGTH_LONGEST_LINK 29 //set to the length to the char length of the longest link
 #define LENGTH_LONGEST_EXTENSION 4 //set to the length of the longest file extension
 
+/* Headshots disabled until further notice
 // Pref option for headshots
 // May need to be regulated sooner than later
 /datum/preference/text/headshot
@@ -52,3 +53,4 @@
 
 #undef LENGTH_LONGEST_LINK
 #undef LENGTH_LONGEST_EXTENSION
+*/

--- a/tgui/packages/tgui/interfaces/ExaminePanel.js
+++ b/tgui/packages/tgui/interfaces/ExaminePanel.js
@@ -11,8 +11,6 @@ export const ExaminePanel = (props, context) => {
     assigned_map,
     flavor_text,
     ooc_notes,
-    custom_species,
-    custom_species_lore,
     headshot,
   } = data;
   return (
@@ -79,21 +77,6 @@ export const ExaminePanel = (props, context) => {
                       title="OOC Notes"
                       preserveWhitespace>
                       {ooc_notes}
-                    </Section>
-                  </Stack.Item>
-                  <Stack.Item grow basis={0}>
-                    <Section
-                      scrollable
-                      fill
-                      title={
-                        custom_species
-                          ? 'Species: ' + custom_species
-                          : 'No Custom Species!'
-                      }
-                      preserveWhitespace>
-                      {custom_species
-                        ? custom_species_lore
-                        : 'Just a normal space dweller.'}
                     </Section>
                   </Stack.Item>
                 </Stack>

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/_multiline_text.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/_multiline_text.tsx
@@ -1,4 +1,4 @@
-import { Feature, FeatureValueProps, FeatureShortTextInput } from '../base';
+import { Feature, FeatureValueProps } from '../base';
 import { Stack, TextArea } from '../../../../../components';
 
 export const MultilineText = (props: FeatureValueProps<string, string>) => {
@@ -56,23 +56,10 @@ export const ooc_notes: Feature<string> = {
   component: MultilineText,
 };
 
-export const headshot: Feature<string> = {
+/* export const headshot: Feature<string> = {
   name: 'Headshot',
   description:
     'Add an image to your character, visible on close examination. Requires it be formatted properly.',
   component: FeatureShortTextInput,
 };
-
-export const custom_species: Feature<string> = {
-  name: 'Custom Species Name',
-  description:
-    "Want to have a fancy species name? Put it here, or leave it blank if you want to use your species' default name.",
-  component: FeatureShortTextInput,
-};
-
-export const custom_species_lore: Feature<string> = {
-  name: 'Custom Species Lore',
-  description:
-    "Add some lore for your species! Won't show up if there's no custom species.",
-  component: MultilineText,
-};
+*/


### PR DESCRIPTION
We went public and I don't feel like seeing people post porn as an option.
People who already have this set, shouldn't affect them I don't think.

## Changelog

:cl: Jolly
del: Headshots pref option has been temporarily removed.
/:cl:

