### PR TITLE
Nukes size respriting in favor of "Funny Humans", or making your legs offensively long

### DIFF
--- a/talestation_modules/code/prefs_module/height.dm
+++ b/talestation_modules/code/prefs_module/height.dm
@@ -10,28 +10,9 @@
 
 #define DEFAULT_HEIGHT "Medium (Default)"
 
-/datum/preference/choiced/mob_height/deserialize(value, datum/preference/choiced/mob_height/mob_height, character_height)
-	if (value in mob_height.old_height_values)
-		return closet_height(value)
-
-	return ..(value)
-
-/datum/preference/choiced/mob_height/proc/closet_height(character_height)
-	switch (character_height)
-		if("Extremely Large")
-			return HUMAN_HEIGHT_TALLEST
-		if("Very Large")
-			return HUMAN_HEIGHT_TALLEST
-		if("Large")
-			return HUMAN_HEIGHT_TALL
-		if("Average Size (Default)")
-			return HUMAN_HEIGHT_MEDIUM
-		if("Small")
-			return HUMAN_HEIGHT_SHORT
-		if("Very Small")
-			return HUMAN_HEIGHT_SHORTEST
-		if("Extremely Small")
-			return HUMAN_HEIGHT_SHORTEST
+// Originally I wanted to do a prefs conversion, but I don't know how to do it
+// And it wouldn't be relevant later anyhow
+// Refer to #5053 if you wanna see how it was going
 
 /datum/preference/choiced/mob_height
 	savefile_key = "character_height_modern"

--- a/talestation_modules/code/prefs_module/height.dm
+++ b/talestation_modules/code/prefs_module/height.dm
@@ -8,90 +8,30 @@
 #define HEIGHT_VERY_SMALL "Very Small"
 #define HEIGHT_EXTREMELY_SMALL "Extremely Small"
 
-/datum/preference/choiced/mob_size
-	// This is legacy "character height". Now "character size". They key remains because I don't want to migrate preferences.
-	savefile_key = "character_height"
-	savefile_identifier = PREFERENCE_CHARACTER
-	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
-	can_randomize = FALSE
-
-/datum/preference/choiced/mob_size/init_possible_values()
-	return list(
-		HEIGHT_EXTREMELY_LARGE,
-		HEIGHT_VERY_LARGE,
-		HEIGHT_LARGE,
-		HEIGHT_NO_CHANGE,
-		HEIGHT_SMALL,
-		HEIGHT_VERY_SMALL,
-		HEIGHT_EXTREMELY_SMALL
-	)
-
-/datum/preference/choiced/mob_size/apply_to_human(mob/living/carbon/human/target, value)
-	if(value == HEIGHT_NO_CHANGE)
-		return
-
-	// Snowflake, but otherwise the dummy in the prefs menu will be resized and you can't see anything
-	if(istype(target, /mob/living/carbon/human/dummy))
-		return
-	// Just in case
-	if(!ishuman(target))
-		return
-
-	target.transform = null
-
-	var/resize_amount = 1
-	var/y_offset = 0
-
-	switch(value)
-		if(HEIGHT_EXTREMELY_LARGE)
-			resize_amount = 1.5
-			y_offset = 8
-		if(HEIGHT_VERY_LARGE)
-			resize_amount = 1.2
-			y_offset = 3
-		if(HEIGHT_LARGE)
-			resize_amount = 1.1
-			y_offset = 2
-		if(HEIGHT_SMALL)
-			resize_amount = 0.9
-			y_offset = -2
-		if(HEIGHT_VERY_SMALL)
-			resize_amount = 0.8
-			y_offset = -3
-		if(HEIGHT_EXTREMELY_SMALL)
-			resize_amount = 0.7
-			y_offset = -5
-
-	if(resize_amount > 1.1)
-		ADD_TRAIT(target, TRAIT_GIANT, ROUNDSTART_TRAIT)
-	else if(resize_amount < 0.9)
-		ADD_TRAIT(target, TRAIT_DWARF, ROUNDSTART_TRAIT)
-
-	target.resize = resize_amount
-	target.update_transform()
-	target.base_pixel_y += y_offset
-	target.pixel_y += y_offset
-
-/datum/preference/choiced/mob_size/is_accessible(datum/preferences/preferences)
-	if(!..(preferences))
-		return FALSE
-
-	var/datum/job/fav_job = preferences.get_highest_priority_job()
-	return !istype(fav_job, /datum/job/ai) && !istype(fav_job, /datum/job/cyborg)
-
-/datum/preference/choiced/mob_size/create_default_value(datum/preferences/preferences)
-	return HEIGHT_NO_CHANGE
-
-
-#undef HEIGHT_EXTREMELY_LARGE
-#undef HEIGHT_VERY_LARGE
-#undef HEIGHT_LARGE
-#undef HEIGHT_NO_CHANGE
-#undef HEIGHT_SMALL
-#undef HEIGHT_VERY_SMALL
-#undef HEIGHT_EXTREMELY_SMALL
-
 #define DEFAULT_HEIGHT "Medium (Default)"
+
+/datum/preference/choiced/mob_height/deserialize(value, datum/preference/choiced/mob_height/mob_height, character_height)
+	if (value in mob_height.old_height_values)
+		return closet_height(value)
+
+	return ..(value)
+
+/datum/preference/choiced/mob_height/proc/closet_height(character_height)
+	switch (character_height)
+		if("Extremely Large")
+			return HUMAN_HEIGHT_TALLEST
+		if("Very Large")
+			return HUMAN_HEIGHT_TALLEST
+		if("Large")
+			return HUMAN_HEIGHT_TALL
+		if("Average Size (Default)")
+			return HUMAN_HEIGHT_MEDIUM
+		if("Small")
+			return HUMAN_HEIGHT_SHORT
+		if("Very Small")
+			return HUMAN_HEIGHT_SHORTEST
+		if("Extremely Small")
+			return HUMAN_HEIGHT_SHORTEST
 
 /datum/preference/choiced/mob_height
 	savefile_key = "character_height_modern"
@@ -104,6 +44,15 @@
 		DEFAULT_HEIGHT = HUMAN_HEIGHT_MEDIUM,
 		"Tall" = HUMAN_HEIGHT_TALL,
 		"Tallest" = HUMAN_HEIGHT_TALLEST,
+	)
+	var/static/list/old_height_values = list(
+		"Extremely Large",
+		"Very Large",
+		"Large",
+		"Average Size (Default)",
+		"Small",
+		"Very Small",
+		"Extremely Small",
 	)
 
 /datum/preference/choiced/mob_height/init_possible_values()

--- a/talestation_modules/code/prefs_module/height.dm
+++ b/talestation_modules/code/prefs_module/height.dm
@@ -3,7 +3,7 @@
 #define HEIGHT_EXTREMELY_LARGE "Extremely Large"
 #define HEIGHT_VERY_LARGE "Very Large"
 #define HEIGHT_LARGE "Large"
-#define HEIGHT_NO_CHANGE "Average Size (Default)"
+#define HEIGHT_NO_CHANGE "Average Height"
 #define HEIGHT_SMALL "Small"
 #define HEIGHT_VERY_SMALL "Very Small"
 #define HEIGHT_EXTREMELY_SMALL "Extremely Small"

--- a/talestation_modules/code/prefs_module/height.dm
+++ b/talestation_modules/code/prefs_module/height.dm
@@ -3,19 +3,19 @@
 #define HEIGHT_EXTREMELY_LARGE "Extremely Large"
 #define HEIGHT_VERY_LARGE "Very Large"
 #define HEIGHT_LARGE "Large"
-#define HEIGHT_NO_CHANGE "Average Height"
+#define HEIGHT_NO_CHANGE "Average Size (Default)"
 #define HEIGHT_SMALL "Small"
 #define HEIGHT_VERY_SMALL "Very Small"
 #define HEIGHT_EXTREMELY_SMALL "Extremely Small"
 
-//TODO: make it so you can input your own height
-/datum/preference/choiced/height
+/datum/preference/choiced/mob_size
+	// This is legacy "character height". Now "character size". They key remains because I don't want to migrate preferences.
 	savefile_key = "character_height"
 	savefile_identifier = PREFERENCE_CHARACTER
 	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
 	can_randomize = FALSE
 
-/datum/preference/choiced/height/init_possible_values()
+/datum/preference/choiced/mob_size/init_possible_values()
 	return list(
 		HEIGHT_EXTREMELY_LARGE,
 		HEIGHT_VERY_LARGE,
@@ -26,11 +26,15 @@
 		HEIGHT_EXTREMELY_SMALL
 	)
 
-/datum/preference/choiced/height/apply_to_human(mob/living/carbon/human/target, value)
+/datum/preference/choiced/mob_size/apply_to_human(mob/living/carbon/human/target, value)
 	if(value == HEIGHT_NO_CHANGE)
 		return
 
+	// Snowflake, but otherwise the dummy in the prefs menu will be resized and you can't see anything
 	if(istype(target, /mob/living/carbon/human/dummy))
+		return
+	// Just in case
+	if(!ishuman(target))
 		return
 
 	target.transform = null
@@ -68,15 +72,16 @@
 	target.base_pixel_y += y_offset
 	target.pixel_y += y_offset
 
-/datum/preference/choiced/height/is_accessible(datum/preferences/preferences)
+/datum/preference/choiced/mob_size/is_accessible(datum/preferences/preferences)
 	if(!..(preferences))
 		return FALSE
 
 	var/datum/job/fav_job = preferences.get_highest_priority_job()
-	return !istype(fav_job, /datum/job/ai) || !istype(fav_job, /datum/job/cyborg)
+	return !istype(fav_job, /datum/job/ai) && !istype(fav_job, /datum/job/cyborg)
 
-/datum/preference/choiced/height/create_default_value(datum/preferences/preferences)
+/datum/preference/choiced/mob_size/create_default_value(datum/preferences/preferences)
 	return HEIGHT_NO_CHANGE
+
 
 #undef HEIGHT_EXTREMELY_LARGE
 #undef HEIGHT_VERY_LARGE
@@ -85,3 +90,45 @@
 #undef HEIGHT_SMALL
 #undef HEIGHT_VERY_SMALL
 #undef HEIGHT_EXTREMELY_SMALL
+
+#define DEFAULT_HEIGHT "Medium (Default)"
+
+/datum/preference/choiced/mob_height
+	savefile_key = "character_height_modern"
+	savefile_identifier = PREFERENCE_CHARACTER
+	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
+	can_randomize = FALSE
+	var/list/height_to_actual = list(
+		"Shortest" = HUMAN_HEIGHT_SHORTEST,
+		"Short" = HUMAN_HEIGHT_SHORT,
+		DEFAULT_HEIGHT = HUMAN_HEIGHT_MEDIUM,
+		"Tall" = HUMAN_HEIGHT_TALL,
+		"Tallest" = HUMAN_HEIGHT_TALLEST,
+	)
+
+/datum/preference/choiced/mob_height/init_possible_values()
+	return assoc_to_keys(height_to_actual)
+
+/datum/preference/choiced/mob_height/apply_to_human(mob/living/carbon/human/target, value)
+	// Just in case
+	if(!ishuman(target))
+		return
+
+	var/height_actual = height_to_actual[value]
+	if(isnull(height_actual))
+		stack_trace("Invalid height for [type], [value]!")
+		return
+
+	target.set_mob_height(height_actual)
+
+/datum/preference/choiced/mob_height/is_accessible(datum/preferences/preferences)
+	if(!..(preferences))
+		return FALSE
+
+	var/datum/job/fav_job = preferences.get_highest_priority_job()
+	return !istype(fav_job, /datum/job/ai) && !istype(fav_job, /datum/job/cyborg)
+
+/datum/preference/choiced/mob_height/create_default_value(datum/preferences/preferences)
+	return DEFAULT_HEIGHT
+
+#undef DEFAULT_HEIGHT

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/_height.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/_height.tsx
@@ -1,10 +1,5 @@
 import { FeatureChoiced, FeatureDropdownInput } from '../base';
 
-export const character_height: FeatureChoiced = {
-  name: 'Character Size',
-  component: FeatureDropdownInput,
-};
-
 export const character_height_modern: FeatureChoiced = {
   name: 'Character Height',
   component: FeatureDropdownInput,

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/_height.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/_height.tsx
@@ -1,6 +1,11 @@
 import { FeatureChoiced, FeatureDropdownInput } from '../base';
 
 export const character_height: FeatureChoiced = {
+  name: 'Character Size',
+  component: FeatureDropdownInput,
+};
+
+export const character_height_modern: FeatureChoiced = {
   name: 'Character Height',
   component: FeatureDropdownInput,
 };


### PR DESCRIPTION
I'm currently working on migrating prefs, so I'll whip up an image later.
I mean, I could do it without needing to migrate prefs, but I don't want to keep the old goofy ass sprite scaling, because its offensive, noisy and annoying.

I prefer humans with offensively long noodle legs anyhow.

Also thanks to Mothblocks for helping me get started.

## Changelog

:cl: Jolly, Melbert
add: Pref heights now make your legs taller or shorter, so, height is actually tangible.
del: However, the OLD way of "heights", which were sprite scaling, has been removed.
/:cl:

