### PR TITLE
Adds some GBP values to a few of our tags

### DIFF
--- a/.github/gbp.toml
+++ b/.github/gbp.toml
@@ -26,5 +26,5 @@ reset_label = "GBP: Reset"
 
 [talestation points]
 "Bounty" = 10
-"Tweak" = 1
+"Tweak" = -1
 "UI" = 4

--- a/.github/gbp.toml
+++ b/.github/gbp.toml
@@ -23,8 +23,6 @@ reset_label = "GBP: Reset"
 "Sound" = 3
 "Sprites" = 3
 "Unit Tests" = 6
-
-[talestation points]
 "Bounty" = 10
 "Tweak" = -1
 "UI" = 4

--- a/.github/gbp.toml
+++ b/.github/gbp.toml
@@ -1,4 +1,5 @@
 no_balance_label = "GBP: No Update"
+no_balance_label = "Manual Mirror"
 reset_label = "GBP: Reset"
 
 [points]
@@ -22,3 +23,8 @@ reset_label = "GBP: Reset"
 "Sound" = 3
 "Sprites" = 3
 "Unit Tests" = 6
+
+[talestation points]
+"Bounty" = 10
+"Tweak" = 1
+"UI" = 4


### PR DESCRIPTION
Manual Mirrors do not affect your GBP, at all.
I originally was going to have them GIVE you points, but I believe them being neutral is far better, as now they shouldn't negatively impact your GBP balance, but it doesn't positively affect it.

Tweak is being treated as a QoL, but feature leaning. I.e tweaking a chem to heal more. While not truly a hard balance change, its a tweak, not a QoL, and as such, is a neg GBP value.

Bounty is there because I do pay people, and they deserve GBP.

UI doesn't exist upstream, so the incentive is real.