### PR TITLE
Fixes spare codes not appearing

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -1003,7 +1003,7 @@ SUBSYSTEM_DEF(job)
 	name = "Nanotrasen-Approved Spare ID Safe Code"
 	desc = "Proof that you have been approved for Captaincy, with all its glory and all its horror."
 
-/obj/item/paper/fluff/spare_id_safe_code/Initialize(mapload)
+/obj/item/paper/paperslip/corporate/fluff/spare_id_safe_code/Initialize(mapload)
 	var/safe_code = SSid_access.spare_id_safe_code // NON-MODULAR CHANGES: Overriding this doesn't work
 	default_raw_text = "Site Director's Spare ID safe code combination: [safe_code ? safe_code : "\[REDACTED\]"]<br><br>The spare ID can be found in its dedicated safe on the bridge.<br><br>If your job would not ordinarily have Head of Staff access, your ID card has been specially modified to possess it."
 	return ..()
@@ -1012,7 +1012,7 @@ SUBSYSTEM_DEF(job)
 	name = "Emergency Spare ID Safe Code Requisition"
 	desc = "Proof that nobody has been approved for Captaincy. A skeleton key for a skeleton shift."
 
-/obj/item/paper/fluff/emergency_spare_id_safe_code/Initialize(mapload)
+/obj/item/paper/paperslip/corporate/fluff/emergency_spare_id_safe_code/Initialize(mapload)
 	var/safe_code = SSid_access.spare_id_safe_code // NON-MODULAR CHANGES: Overriding this doesn't work
 	default_raw_text = "Site Director's Spare ID safe code combination: [safe_code ? safe_code : "\[REDACTED\]"]<br><br>The spare ID can be found in its dedicated safe on the bridge."
 	return ..()

--- a/talestation_modules/code/fluff_module/jobs/overrides/captain.dm
+++ b/talestation_modules/code/fluff_module/jobs/overrides/captain.dm
@@ -3,11 +3,11 @@
 */
 
 // Changes spare id desc
-/obj/item/paper/fluff/spare_id_safe_code
+/obj/item/paper/paperslip/corporate/fluff/spare_id_safe_code
 	desc = "Proof that you have been approved for temporary leadership, with all its glory and all its horror."
 
 // Changes emergency spare desc
-/obj/item/paper/fluff/emergency_spare_id_safe_code
+/obj/item/paper/paperslip/corporate/fluff/emergency_spare_id_safe_code
 	desc = "Proof that nobody has been approved for temporary leadership. A skeleton key for a skeleton shift."
 
 // Changes captain ian stuff


### PR DESCRIPTION
Fixes: #5623

## Changelog

:cl: Jolly
fix: Spare codes should manifest once again.
/:cl:
