### PR TITLE
Makes Flavor Text stuff config related

### DIFF
--- a/code/___MODULAR_DEFINES/defines.dm
+++ b/code/___MODULAR_DEFINES/defines.dm
@@ -58,10 +58,6 @@
 
 /// How many characters will be displayed in the flavor text preview before we cut it off?
 #define FLAVOR_PREVIEW_LIMIT 110
-// NON-MODULAR CHANGES END
-
-/// Min flavor text required to join a round
-#define FLAVOR_TEXT_CHAR_REQUIREMENT 125
 
 /*
 * Pain Defines

--- a/code/_onclick/hud/new_player.dm
+++ b/code/_onclick/hud/new_player.dm
@@ -151,11 +151,12 @@
 	var/mob/dead/new_player/new_player = hud.mymob
 
 	// NON-MODULAR CHANGES: Minimal flavor text
-	if(!is_admin(new_player.client) && length_char(new_player.client?.prefs?.read_preference(/datum/preference/text/flavor_text)) < FLAVOR_TEXT_CHAR_REQUIREMENT)
-		to_chat(new_player, span_notice("You need at least [FLAVOR_TEXT_CHAR_REQUIREMENT] characters of flavor text to join the round. \
+	if(CONFIG_GET(flag/min_flavor_text))
+		if(length_char(new_player.client.prefs.read_preference(/datum/preference/text/flavor_text)) <= CONFIG_GET(number/flavor_text_character_requirement))
+			to_chat(new_player, span_notice("You need at least [CONFIG_GET(number/flavor_text_character_requirement)] characters of flavor text to join the round. \
 						You have [length_char(new_player.client.prefs.read_preference(/datum/preference/text/flavor_text))] characters. \
 						Junk flavor text will get you banned. Put effort into it."))
-		return
+			return
 	// NON-MODULAR CHANGES END
 
 	ready = !ready
@@ -206,6 +207,15 @@
 
 	var/mob/dead/new_player/new_player = hud.mymob
 
+	// NON-MODULAR CHANGES: Minimal flavor text
+	if(CONFIG_GET(flag/min_flavor_text))
+		if(length_char(new_player.client.prefs.read_preference(/datum/preference/text/flavor_text)) <= CONFIG_GET(number/flavor_text_character_requirement))
+			to_chat(new_player, span_notice("You need at least [CONFIG_GET(number/flavor_text_character_requirement)] characters of flavor text to join the round. \
+						You have [length_char(new_player.client.prefs.read_preference(/datum/preference/text/flavor_text))] characters. \
+						Junk flavor text will get you banned. Put effort into it."))
+			return
+	// NON-MODULAR CHANGES END
+
 	if(SSticker.queued_players.len || (relevant_cap && living_player_count() >= relevant_cap && !(ckey(new_player.key) in GLOB.admin_datums)))
 		to_chat(new_player, span_danger("[CONFIG_GET(string/hard_popcap_message)]"))
 
@@ -218,14 +228,6 @@
 			SSticker.queued_players += new_player
 			to_chat(new_player, span_notice("You have been added to the queue to join the game. Your position in queue is [SSticker.queued_players.len]."))
 		return
-
-	// NON-MODULAR CHANGES: Minimal flavor text
-	if(length_char(new_player.client.prefs.read_preference(/datum/preference/text/flavor_text)) <= FLAVOR_TEXT_CHAR_REQUIREMENT)
-		to_chat(new_player, span_notice("You need at least [FLAVOR_TEXT_CHAR_REQUIREMENT] characters of flavor text to join the round. \
-						You have [length_char(new_player.client.prefs.read_preference(/datum/preference/text/flavor_text))] characters. \
-						Junk flavor text will get you banned. Put effort into it."))
-		return
-	// NON-MODULAR CHANGES END
 
 	if(!LAZYACCESS(params2list(params), CTRL_CLICK))
 		GLOB.latejoin_menu.ui_interact(new_player)
@@ -265,6 +267,14 @@
 	if(!.)
 		return
 	var/mob/dead/new_player/new_player = hud.mymob
+	// NON-MODULAR CHANGES: Minimal flavor text
+	if(CONFIG_GET(flag/min_flavor_text))
+		if(length_char(new_player.client.prefs.read_preference(/datum/preference/text/flavor_text)) <= CONFIG_GET(number/flavor_text_character_requirement))
+			to_chat(new_player, span_notice("You need at least [CONFIG_GET(number/flavor_text_character_requirement)] characters of flavor text to observe the round. \
+						You have [length_char(new_player.client.prefs.read_preference(/datum/preference/text/flavor_text))] characters. \
+						Junk flavor text will get you banned. Put effort into it."))
+			return
+	// NON-MODULAR CHANGES END
 	new_player.make_me_an_observer()
 
 /atom/movable/screen/lobby/button/observe/proc/enable_observing()

--- a/config/talestation_config.txt
+++ b/config/talestation_config.txt
@@ -30,3 +30,11 @@ TRANSFER_CALL_REASON "Crew transfer vote successful, dispatching shuttle for shi
 ## Discord role ping - Put the role ID here
 ## THIS REQUIRES TGS TO WORK
 #PING_ROLE_ID
+
+## Uncomment to enable minimum flavor text requirements for joining the round
+#MIN_FLAVOR_TEXT
+
+## Minimum flavor text number needed to enter the game
+## YOU MUST HAVE MIN_FLAVOR_TEXT ENABLED FOR THIS TO WORK.
+## Don't ever set this to 0, just disable MIN_FLAVOR_TEXT
+#FLAVOR_TEXT_CHARACTER_REQUIREMENT 125

--- a/talestation_modules/code/config_module/datum_entries.dm
+++ b/talestation_modules/code/config_module/datum_entries.dm
@@ -39,3 +39,13 @@
 /// Config entry for Discord server role
 // No default value
 /datum/config_entry/string/ping_role_id
+
+/// Config entry for enabling flavortext min character count, good to disable for debugging purposes
+// DISABLE THIS instead of setting flavor_text_character_requirement to 0 or I'll chop your arms off
+/datum/config_entry/flag/min_flavor_text
+	default = FALSE
+
+/// Config entry for enabling flavortext min character count, good to disable for debugging purposes
+// NEVER set this value to 0!!
+/datum/config_entry/number/flavor_text_character_requirement
+	default = 125


### PR DESCRIPTION
I don't know if I fixed a potential exploit or not.

## Changelog

:cl: Jolly
add: To observe, you now must have your flavor text set.
config: Flavor text enforcement is now via config.
config: Flavor text minimum character limit is now enforced via config.
/:cl:

