### PR TITLE
Fix resource pod runtime

### DIFF
--- a/talestation_modules/code/events_module/resource_drift/resource_pods.dm
+++ b/talestation_modules/code/events_module/resource_drift/resource_pods.dm
@@ -148,7 +148,7 @@
 
 		allowed_areas = make_associative(GLOB.the_station_areas) - safe_area_types
 
-	var/list/possible_areas = typecache_filter_list(GLOB.sortedAreas,allowed_areas)
+	var/list/possible_areas = typecache_filter_list(get_sorted_areas(),allowed_areas)
 	if (length(possible_areas))
 		var/chosen_area = pick(possible_areas)
 		while(possible_areas)


### PR DESCRIPTION

## About The Pull Request
GLOB.sortedAreas is null until called get_sorted_areas is called at least once. Can just use get_sorted_areas to solve the issue since it'll only generate the list once anyways (as long as it is not null)

## How does it improve TaleStation
event machine no broke

## Changelog
:cl:
fix: Resource pod event should now work properly again
/:cl:
