### PR TITLE
Flavor records are readable with their respective huds (take 2)

### DIFF
--- a/code/___MODULAR_DEFINES/defines.dm
+++ b/code/___MODULAR_DEFINES/defines.dm
@@ -55,9 +55,10 @@
 */
 /// Max amount of flavor text allowed
 #define MAX_FLAVOR_LEN 4096
-
 /// How many characters will be displayed in the flavor text preview before we cut it off?
 #define FLAVOR_PREVIEW_LIMIT 110
+/// The length of records at which they will not show up, to prevent empty records from appearing.
+#define RECORDS_INVISIBLE_THRESHOLD 0
 
 /*
 * Pain Defines

--- a/code/datums/records/manifest.dm
+++ b/code/datums/records/manifest.dm
@@ -16,7 +16,7 @@ GLOBAL_DATUM_INIT(manifest, /datum/manifest, new)
 		if(readied_player.new_character)
 			log_manifest(readied_player.ckey,readied_player.new_character.mind,readied_player.new_character)
 		if(ishuman(readied_player.new_character))
-			inject(readied_player.new_character)
+			inject(readied_player.new_character, readied_player.client) // NON-MODULAR CHANGES: Adds records
 		CHECK_TICK
 
 /// Gets the current manifest.
@@ -97,7 +97,7 @@ GLOBAL_DATUM_INIT(manifest, /datum/manifest, new)
 
 
 /// Injects a record into the manifest.
-/datum/manifest/proc/inject(mob/living/carbon/human/person)
+/datum/manifest/proc/inject(mob/living/carbon/human/person, client/person_client) // NON-MODULAR CHANGES: Adds client args
 	set waitfor = FALSE
 	if(!(person.mind?.assigned_role.job_flags & JOB_CREW_MANIFEST))
 		return
@@ -146,6 +146,11 @@ GLOBAL_DATUM_INIT(manifest, /datum/manifest, new)
 		minor_disabilities = person.get_quirk_string(FALSE, CAT_QUIRK_MINOR_DISABILITY),
 		minor_disabilities_desc = person.get_quirk_string(TRUE, CAT_QUIRK_MINOR_DISABILITY),
 		quirk_notes = person.get_quirk_string(TRUE, CAT_QUIRK_NOTES),
+		// NON-MODULAR CHANGES: Adds records
+		old_general_records = person_client?.prefs.read_preference(/datum/preference/multiline_text/flavor_datum/general) || "",
+		old_medical_records = person_client?.prefs.read_preference(/datum/preference/multiline_text/flavor_datum/medical) || "",
+		old_security_records = person_client?.prefs.read_preference(/datum/preference/multiline_text/flavor_datum/security) || "",
+		// NON-MODULAR CHANGES END
 	)
 
 	return

--- a/code/datums/records/record.dm
+++ b/code/datums/records/record.dm
@@ -102,6 +102,11 @@
 	physical_status = PHYSICAL_ACTIVE,
 	mental_status = MENTAL_STABLE,
 	quirk_notes,
+	// NON-MODULAR CHANGES: Adds records
+	old_general_records = "",
+	old_medical_records = "",
+	old_security_records = "",
+	// NON-MODULAR CHANGES END
 )
 	. = ..()
 	src.lock_ref = lock_ref
@@ -112,6 +117,10 @@
 	src.physical_status = physical_status
 	src.mental_status = mental_status
 	src.quirk_notes = quirk_notes
+	// NON-MODULAR CHANGES: Adds records
+	src.old_general_records = old_general_records
+	src.old_medical_records = old_medical_records
+	src.old_security_records = old_security_records
 
 	GLOB.manifest.general += src
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -387,6 +387,10 @@
 			if(target_record)
 				. += "<a href='?src=[REF(src)];hud=m;evaluation=1;examine_time=[world.time]'>\[Medical evaluation\]</a><br>"
 			. += "<a href='?src=[REF(src)];hud=m;quirk=1;examine_time=[world.time]'>\[See quirks\]</a>"
+		//SKYRAT EDIT ADDITION BEGIN - EXAMINE RECORDS
+			if(target_record && length(target_record.old_medical_records) > RECORDS_INVISIBLE_THRESHOLD)
+				. += "<a href='?src=[REF(src)];hud=m;medrecords=1;examine_time=[world.time]'>\[View medical records\]</a>"
+			//SKYRAT EDIT END
 
 		if(HAS_TRAIT(user, TRAIT_SECURITY_HUD))
 			if(!user.stat && user != src)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -204,6 +204,12 @@
 					to_chat(human_user,  "<span class='notice ml-1'>Detected physiological traits:</span>\n<span class='notice ml-2'>[quirkstring]</span>")
 				else
 					to_chat(human_user,  "<span class='notice ml-1'>No physiological traits found.</span>")
+			//SKYRAT EDIT ADDITION BEGIN - EXAMINE RECORDS
+			if(href_list["medrecords"])
+				to_chat(usr, "<b>Medical Record:</b> [target_record.old_medical_records]")
+			if(href_list["genrecords"])
+				to_chat(usr, "<b>General Record:</b> [target_record.old_general_records]")
+			//SKYRAT EDIT END
 			return //Medical HUD ends here.
 
 		if(href_list["hud"] == "s")

--- a/talestation_modules/code/flavor_module/flavor_text.dm
+++ b/talestation_modules/code/flavor_module/flavor_text.dm
@@ -4,11 +4,11 @@
 */
 /datum/record
 	/// Var used to pass general record information
-	var/old_general_records = "Unknown"
+	var/old_general_records
 	/// Var used to pass medical record information
-	var/old_medical_records = "Unknown"
+	var/old_medical_records
 	/// Var used to pass security record information
-	var/old_security_records = "Unknown"
+	var/old_security_records
 
 /datum/antagonist
 	/// Whether this antag can see exploitable info on examine.


### PR DESCRIPTION
Now with less code culling.
Fixes: #4280

Trying to figure out how to properly pass the prefs info to be read.

## Changelog

:cl: Jolly
fix: Flavor records (medical, sec and general) can now be read from their respective HUDs.
/:cl:
