### PR TITLE
Bubblegum no longer causes flavortext to brick itself

### DIFF
--- a/talestation_modules/code/clothing_module/clothing.dm
+++ b/talestation_modules/code/clothing_module/clothing.dm
@@ -4,3 +4,7 @@
 	* Used to check if our flavor test is obscured
 	*/
 	var/covers_face = FALSE
+
+/obj/item/food/bubblegum
+	/// Used for not hiding flavor text
+	var/covers_face = FALSE


### PR DESCRIPTION
Fixes: #5861

## Changelog

:cl: Jolly
fix: Bubblegum (food) should no longer brick flavor text.
/:cl:
