### PR TITLE
LOOC cannot be used by observers anymore (unless they're an admin)

### DIFF
--- a/talestation_modules/code/looc_module/looc.dm
+++ b/talestation_modules/code/looc_module/looc.dm
@@ -27,6 +27,9 @@ GLOBAL_VAR_INIT(looc_allowed, TRUE)
 		if(prefs.muted & MUTE_OOC)
 			to_chat(src, span_danger("You cannot use LOOC (muted)."))
 			return
+		if(istype(mob, /mob/dead/observer))
+			to_chat(src, span_danger("The dead can't use LOOC! Use OOC."))
+			return
 	else
 		if(!GLOB.looc_allowed)
 			to_chat(src, span_danger("LOOC is globally muted, but you are bypassing it as an admin."))


### PR DESCRIPTION
Fixes: #5849

## Changelog

:cl: Jolly
add: Observers can no longer use LOOC (unless you're an admin).
/:cl:

