### PR TITLE
Map Reset 6/5

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -2904,6 +2904,7 @@
 /obj/item/lighter{
 	pixel_x = 15
 	},
+/obj/item/clothing/mask/breath/medical,
 /turf/open/floor/iron/white,
 /area/station/science/robotics/augments)
 "boY" = (
@@ -19348,6 +19349,7 @@
 "hnP" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/machinery/status_display/evac/directional/south,
+/obj/structure/tank_holder/anesthetic,
 /turf/open/floor/iron,
 /area/station/science/robotics/augments)
 "hnV" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -9568,6 +9568,7 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 4
 	},
+/obj/structure/tank_holder/anesthetic,
 /turf/open/floor/iron/dark/textured_half,
 /area/station/science/robotics/lab)
 "cnl" = (
@@ -43706,6 +43707,7 @@
 	pixel_x = -10;
 	pixel_y = -4
 	},
+/obj/item/clothing/mask/breath/medical,
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "kSc" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -69170,6 +69170,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/central/lesser)
+"wdD" = (
+/obj/structure/tank_holder/anesthetic,
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/lab)
 "wdI" = (
 /obj/effect/turf_decal/trimline/neutral/warning{
 	dir = 6
@@ -69617,6 +69621,7 @@
 /obj/structure/table,
 /obj/item/storage/box/bodybags,
 /obj/item/pen,
+/obj/item/clothing/mask/breath/medical,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "wkV" = (
@@ -250328,7 +250333,7 @@ apM
 uvt
 kBT
 pra
-pra
+wdD
 mtI
 uxj
 eNK

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -12451,6 +12451,8 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/window/spawner/directional/west,
 /obj/structure/window/spawner/directional/north,
+/obj/item/tank/internals/anesthetic,
+/obj/item/clothing/mask/breath/medical,
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "eEV" = (

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -17,6 +17,13 @@
 /obj/structure/sign/poster/official/random/directional/west,
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
+"aaq" = (
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white/textured,
+/area/station/medical/storage)
 "aat" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/structure/cable,
@@ -308,6 +315,17 @@
 /obj/effect/turf_decal/trimline/blue/line,
 /turf/open/floor/carpet/blue,
 /area/station/command/meeting_room)
+"adh" = (
+/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
+/obj/machinery/door/window/brigdoor/left/directional/east{
+	name = "Anesthetic Storage";
+	req_access = list("medical")
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/storage)
 "adk" = (
 /obj/structure/grille,
 /obj/structure/sign/directions/medical/directional/north,
@@ -319,6 +337,13 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/hallway/floor1/fore)
+"adm" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "adq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -326,12 +351,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/floor2/port)
+"adt" = (
+/obj/effect/turf_decal/siding/wideplating,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/chem_dispenser,
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/pharmacy)
 "adB" = (
-/obj/structure/closet/crate/bin{
-	name = "biowaste bin"
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
-/area/station/medical/surgery/aft)
+/area/station/medical/office)
 "adD" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/yellow{
@@ -467,6 +500,13 @@
 /obj/effect/turf_decal/trimline/purple,
 /turf/open/floor/engine/plasma,
 /area/station/engineering/atmos)
+"aft" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/grille/broken,
+/obj/structure/ladder,
+/turf/open/floor/plating,
+/area/station/hallway/floor2/aft)
 "afz" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners{
 	dir = 8
@@ -542,13 +582,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor1/port/fore)
-"agv" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/effect/landmark/start/medical_doctor,
-/turf/open/floor/iron/dark,
-/area/station/medical/surgery/aft)
 "agJ" = (
 /obj/machinery/modular_computer/console/preset/cargochat/science,
 /obj/effect/turf_decal/tile/brown/opposingcorners,
@@ -807,9 +840,7 @@
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/starboard/aft)
 "ajq" = (
-/obj/structure/table/wood,
-/obj/machinery/newscaster/directional/south,
-/turf/open/floor/carpet/royalblue,
+/turf/closed/wall/r_wall,
 /area/station/medical/break_room)
 "ajs" = (
 /turf/open/floor/pod/light,
@@ -1135,13 +1166,6 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron,
 /area/station/maintenance/floor1/port/aft)
-"anQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/light/cold/directional/north,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/department/medical)
 "anW" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -1602,13 +1626,6 @@
 /obj/item/stack/cable_coil,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port/fore)
-"atp" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/effect/landmark/navigate_destination/med,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
 "atv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/wood/large,
@@ -1903,6 +1920,13 @@
 	},
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor2/starboard/aft)
+"axh" = (
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/effect/turf_decal/siding/white/end{
+	dir = 8
+	},
+/turf/open/floor/iron/white/textured,
+/area/station/medical/cryo)
 "axn" = (
 /obj/structure/window/reinforced/tinted/spawner/directional/west,
 /obj/structure/chair/office{
@@ -1964,6 +1988,24 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison/work)
+"ayh" = (
+/obj/structure/table/reinforced,
+/obj/item/grenade/chem_grenade{
+	pixel_x = -4
+	},
+/obj/item/grenade/chem_grenade{
+	pixel_x = 5
+	},
+/obj/item/grenade/chem_grenade,
+/obj/item/stack/cable_coil,
+/obj/item/screwdriver{
+	pixel_y = 10
+	},
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/machinery/light/cold/directional/south,
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron/white,
+/area/station/medical/pharmacy)
 "ayi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1978,11 +2020,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/service/chapel)
-"ayo" = (
-/obj/effect/spawner/random/structure/girder,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/pod/dark,
-/area/station/maintenance/floor2/port)
 "ayv" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
@@ -1998,6 +2035,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor1/fore)
+"ayw" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "ayB" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
@@ -2017,6 +2063,11 @@
 /obj/structure/sign/warning/docking,
 /turf/closed/wall/r_wall,
 /area/station/security/execution/transfer)
+"ayK" = (
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/suit_storage_unit/medical,
+/turf/open/floor/iron/white/textured,
+/area/station/medical/storage)
 "ayU" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/red/dim/directional/east,
@@ -2713,13 +2764,21 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/prison/work)
+"aHD" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white,
+/area/station/medical/office)
 "aHG" = (
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/medical/treatment_center)
 "aHM" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/spawner/random/structure/crate_empty,
@@ -2772,6 +2831,13 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor3/aft)
+"aIw" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/storage)
 "aIB" = (
 /obj/structure/window/reinforced/plasma/spawner/directional/south,
 /obj/machinery/power/energy_accumulator/grounding_rod/anchored,
@@ -2780,18 +2846,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer4,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter)
-"aIK" = (
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/structure/table/glass,
-/obj/item/reagent_containers/cup/bottle/epinephrine,
-/obj/item/reagent_containers/cup/bottle/multiver{
-	pixel_x = 6
-	},
-/obj/item/reagent_containers/syringe,
-/obj/structure/sign/poster/official/random/directional/west,
-/obj/structure/sign/departments/medbay/alt/directional/north,
-/turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
 "aIV" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
@@ -3148,14 +3202,6 @@
 /obj/structure/chair/comfy/shuttle,
 /turf/open/floor/mineral/plastitanium,
 /area/station/maintenance/floor2/starboard/aft)
-"aOd" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/machinery/firealarm/directional/west,
-/obj/structure/sink/directional/east,
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
 "aOp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3165,6 +3211,13 @@
 	dir = 1
 	},
 /area/station/hallway/floor2/aft)
+"aOs" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/effect/landmark/start/medical_doctor,
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/surgery/aft)
 "aOt" = (
 /obj/structure/railing{
 	dir = 1
@@ -3308,6 +3361,19 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet/red,
 /area/station/service/library/lounge)
+"aQo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/aft)
 "aQA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /obj/effect/turf_decal/trimline/yellow/line,
@@ -3465,13 +3531,15 @@
 /turf/open/floor/iron/solarpanel/airless,
 /area/station/solars/port/aft)
 "aSa" = (
-/obj/structure/chair/comfy/brown{
-	dir = 8
+/obj/structure/table/wood,
+/obj/machinery/fax{
+	fax_name = "Chief Medical Officer's Office";
+	name = "Chief Medical Officer's Fax Machine"
 	},
-/obj/machinery/light/warm/directional/east,
-/obj/effect/landmark/start/medical_doctor,
-/turf/open/floor/carpet/royalblue,
-/area/station/medical/break_room)
+/obj/machinery/duct,
+/obj/structure/sign/poster/official/random/directional/south,
+/turf/open/floor/wood/parquet,
+/area/station/command/heads_quarters/cmo)
 "aSb" = (
 /obj/structure/chair/stool/bar/directional/north,
 /obj/effect/turf_decal/tile/purple/fourcorners,
@@ -3686,11 +3754,6 @@
 	dir = 4
 	},
 /area/station/hallway/secondary/service)
-"aUz" = (
-/obj/machinery/suit_storage_unit/cmo,
-/obj/item/radio/intercom/directional/west,
-/turf/open/floor/wood/parquet,
-/area/station/command/heads_quarters/cmo)
 "aUG" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/random/structure/table_or_rack,
@@ -3788,6 +3851,10 @@
 /obj/structure/sign/directions/evac/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/floor3/aft)
+"aWb" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/medical/medbay/central)
 "aWc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3833,6 +3900,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
+"aWl" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/iron/white,
+/area/station/medical/storage)
 "aWq" = (
 /obj/structure/table/optable,
 /obj/effect/turf_decal/trimline/blue/filled/line,
@@ -3905,10 +3979,6 @@
 /obj/machinery/recharge_station,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/science/robotics/mechbay)
-"aWU" = (
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white/side,
-/area/station/medical/medbay/lobby)
 "aWV" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -4100,12 +4170,10 @@
 /turf/open/floor/iron/smooth,
 /area/station/construction)
 "aYT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/item/toy/snappop,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor2/port)
+/obj/structure/table/optable,
+/obj/machinery/defibrillator_mount/directional/south,
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/surgery/fore)
 "aZd" = (
 /obj/machinery/reagentgrinder,
 /obj/structure/table,
@@ -4141,15 +4209,11 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "aZu" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/medical/treatment_center)
 "aZw" = (
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor3/port/fore)
@@ -4255,6 +4319,19 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/science/lab)
+"baw" = (
+/obj/effect/mapping_helpers/airlock/access/all/medical/pharmacy,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Pharmacy"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white,
+/area/station/medical/pharmacy)
 "baA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -4280,7 +4357,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue/fourcorners,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white/textured,
 /area/station/medical/break_room)
 "bbo" = (
 /obj/effect/spawner/structure/window,
@@ -4447,6 +4524,12 @@
 /obj/structure/chair/bronze,
 /turf/open/floor/bronze/filled,
 /area/station/maintenance/floor1/starboard)
+"bdF" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/paramedic)
 "bdN" = (
 /obj/structure/table,
 /obj/item/stack/sheet/iron/fifty,
@@ -4498,11 +4581,13 @@
 	},
 /area/station/hallway/floor2/aft)
 "beu" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/station/medical/medbay/aft)
 "bew" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron,
@@ -4537,11 +4622,11 @@
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/starboard/fore)
 "beT" = (
-/obj/structure/chair/office/tactical{
-	dir = 1
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
 	},
-/turf/open/floor/iron/dark/textured,
-/area/station/medical/morgue)
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "bfe" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/turf_decal/bot,
@@ -4625,12 +4710,12 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "bfM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/holopad,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/station/medical/treatment_center)
 "bfT" = (
 /obj/effect/turf_decal/trimline/blue/line{
 	dir = 8
@@ -5274,6 +5359,11 @@
 /obj/effect/landmark/navigate_destination/tcomms,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/tcommsat/computer)
+"bnd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/light/cold/directional/north,
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/cryo)
 "bne" = (
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor3/port/fore)
@@ -5614,8 +5704,8 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor4/fore)
 "bqY" = (
-/obj/machinery/vending/cola/pwr_game,
 /obj/effect/turf_decal/siding/wood,
+/obj/machinery/vending/cola/pwr_game,
 /obj/structure/sign/poster/contraband/pwr_game/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/break_room)
@@ -5869,21 +5959,13 @@
 	},
 /area/station/science/robotics/lab)
 "btv" = (
-/obj/effect/mapping_helpers/airlock/access/any/medical/general,
-/obj/effect/mapping_helpers/airlock/access/any/medical/general,
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "med_doors";
-	name = "Medical Front Door"
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/unres,
-/obj/machinery/door/firedoor,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/medical/treatment_center)
 "bty" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
@@ -6144,11 +6226,6 @@
 /obj/effect/spawner/random/structure/grille,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port/fore)
-"bwk" = (
-/obj/effect/spawner/random/maintenance/three,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/pod/dark,
-/area/station/maintenance/floor2/port)
 "bwl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -6271,12 +6348,11 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/science/robotics/lab)
 "bxu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/spawner/random/engineering/atmospherics_portable,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/structure/table/glass,
+/obj/item/bonesetter,
+/obj/item/stack/medical/bone_gel/four,
+/turf/open/floor/iron/white/textured,
 /area/station/medical/treatment_center)
 "bxG" = (
 /obj/item/radio/intercom/directional/east,
@@ -6287,17 +6363,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/fakebasalt,
 /area/station/maintenance/floor3/port)
-"bxQ" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
 "bxT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -6596,12 +6661,14 @@
 /turf/open/floor/catwalk_floor/iron_white,
 /area/station/cargo/miningdock)
 "bBj" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/machinery/holopad,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/medical/paramedic)
 "bBw" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -6736,6 +6803,19 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
+"bDh" = (
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/command/heads_quarters/cmo)
 "bDm" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/delivery,
@@ -6957,13 +7037,6 @@
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/wood,
 /area/station/command/meeting_room)
-"bGT" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 8
-	},
-/obj/machinery/holopad,
-/turf/open/floor/iron/white,
-/area/station/medical/exam_room)
 "bHh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/line{
@@ -7187,11 +7260,8 @@
 /area/station/maintenance/disposal/incinerator)
 "bKz" = (
 /obj/structure/railing/corner,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/catwalk_floor,
-/area/station/maintenance/department/medical)
+/area/station/hallway/floor2/fore)
 "bKG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/sign/poster/contraband/random/directional/north,
@@ -7255,25 +7325,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
-"bLW" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/left/directional/north{
-	name = "Pharmacy Desk"
-	},
-/obj/machinery/door/window/left/directional/north{
-	dir = 2;
-	name = "Pharmacy Desk";
-	req_access = list("pharmacy")
-	},
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 1;
-	id = "chem-lockdown";
-	name = "Chemistry Shutters"
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/pharmacy)
 "bLX" = (
 /obj/machinery/door/window/left/directional/north{
 	name = "Hydroponics Garden";
@@ -7336,12 +7387,10 @@
 /turf/open/floor/carpet/royalblack,
 /area/station/service/kitchen/diner)
 "bMx" = (
-/obj/machinery/computer/operating{
-	dir = 1
-	},
-/obj/machinery/vending/wallmed/directional/south,
-/turf/open/floor/iron/dark/textured,
-/area/station/medical/surgery/aft)
+/obj/structure/curtain,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/white/textured,
+/area/station/medical/office)
 "bMz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/girder,
@@ -7460,14 +7509,21 @@
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/storage)
 "bNQ" = (
-/obj/item/radio/intercom/directional/west,
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/filingcabinet/chestdrawer,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/railing{
+	dir = 8
 	},
-/turf/open/floor/iron/dark/textured,
-/area/station/medical/morgue)
+/obj/structure/chair/sofa/bench/solo{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "bNR" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Atmospherics-Supermatter Connection"
@@ -7544,11 +7600,11 @@
 /turf/open/floor/iron/smooth,
 /area/station/hallway/floor2/fore)
 "bPo" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/storage)
+/area/station/medical/office)
 "bPr" = (
 /obj/structure/mirror/directional/north,
 /obj/machinery/camera/directional/west{
@@ -7998,9 +8054,21 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/floor3/aft)
+"bVb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "bVd" = (
-/obj/effect/turf_decal/trimline/blue/mid_joiner{
-	dir = 4
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/poddoor/preopen{
+	elevator_linked_id = "com_vator";
+	elevator_mode = 1
 	},
 /obj/effect/turf_decal/trimline/blue/line{
 	dir = 4
@@ -8008,12 +8076,6 @@
 /obj/effect/turf_decal/trimline/purple/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/purple/mid_joiner{
-	dir = 8
-	},
-/obj/item/storage/toolbox/emergency,
-/obj/structure/table/reinforced,
-/obj/structure/sign/poster/official/random/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor2/fore)
 "bVj" = (
@@ -8059,14 +8121,12 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "bVP" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/arrow_cw{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/table/reinforced/rglass,
+/obj/item/storage/medkit/surgery,
+/obj/item/storage/medkit/advanced,
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/cmo)
 "bVQ" = (
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/structure/window/reinforced/spawner/directional/west,
@@ -8126,6 +8186,14 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/iron/white,
 /area/station/hallway/floor2/aft)
+"bXd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/camera/autoname/directional/south,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "bXe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
@@ -8185,12 +8253,6 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/station/science/ordnance/freezerchamber)
-"bYn" = (
-/obj/structure/closet/crate/freezer/blood,
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/machinery/light/cold/directional/west,
-/turf/open/floor/iron/white,
-/area/station/medical/surgery/fore)
 "bYq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -8486,18 +8548,17 @@
 /turf/closed/wall/r_wall,
 /area/station/maintenance/floor3/starboard/fore)
 "ccI" = (
-/obj/structure/table/reinforced/rglass,
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/left/directional/west{
-	name = "Medbay Front Desk";
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/obj/machinery/button/door/directional/south{
+	id = "med_doors";
+	name = "Medbay Door Control";
+	normaldoorcontrol = 1;
 	req_access = list("medical")
 	},
-/obj/structure/desk_bell{
-	pixel_x = 7
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/paramedic)
 "ccK" = (
 /obj/effect/decal/cleanable/blood/footprints,
 /obj/effect/decal/cleanable/blood/tracks{
@@ -8770,15 +8831,14 @@
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor2/starboard)
 "cgd" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/tile/blue/full,
+/obj/machinery/medical_kiosk,
+/obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/obj/machinery/duct,
+/turf/open/floor/iron/white/textured,
+/area/station/medical/treatment_center)
 "cgi" = (
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor1/port/fore)
@@ -8800,12 +8860,10 @@
 /turf/open/floor/iron/dark,
 /area/station/commons/storage/tools)
 "cgt" = (
-/obj/machinery/camera/autoname/directional/east,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/station/medical/medbay/lobby)
 "cgv" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -8831,10 +8889,13 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/floor1/port/aft)
 "cgz" = (
-/obj/machinery/firealarm/directional/south,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/obj/machinery/light/cold/no_nightlight/directional/south,
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/floor2/aft)
 "cgB" = (
@@ -8927,16 +8988,16 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "cil" = (
-/obj/machinery/door/airlock/medical{
-	name = "Recovery Room"
+/obj/structure/chair/office{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
-/area/station/medical/exam_room)
+/area/station/command/heads_quarters/cmo)
 "cim" = (
 /obj/structure/stairs/north,
 /obj/structure/sign/departments/cargo/directional/east,
@@ -9290,6 +9351,16 @@
 /obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/security/evidence)
+"cme" = (
+/obj/structure/table,
+/obj/item/folder/white,
+/obj/machinery/camera/autoname/directional/north,
+/obj/item/paper_bin,
+/obj/effect/turf_decal/siding/white/corner,
+/obj/machinery/newscaster/directional/north,
+/obj/item/healthanalyzer,
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/paramedic)
 "cmh" = (
 /obj/structure/closet/toolcloset,
 /obj/effect/decal/cleanable/dirt,
@@ -9348,7 +9419,7 @@
 /area/station/maintenance/floor4/starboard/fore)
 "cmC" = (
 /obj/effect/turf_decal/trimline/white/filled/corner,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/dark,
 /area/station/medical/psychology)
 "cmG" = (
 /turf/closed/wall,
@@ -9490,6 +9561,12 @@
 /obj/machinery/holopad,
 /turf/open/floor/carpet,
 /area/station/hallway/secondary/entry)
+"cpj" = (
+/obj/machinery/iv_drip,
+/obj/structure/mirror/directional/south,
+/obj/structure/sign/poster/official/cleanliness/directional/east,
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/surgery/aft)
 "cpk" = (
 /obj/vehicle/ridden/janicart,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -9545,6 +9622,12 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood/tile,
 /area/station/service/chapel/office)
+"cpV" = (
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/structure/closet/secure_closet/medical3,
+/obj/machinery/light/cold/directional/south,
+/turf/open/floor/iron/white/textured,
+/area/station/medical/storage)
 "cpW" = (
 /obj/machinery/light/small/directional/west,
 /obj/structure/cable,
@@ -9728,17 +9811,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/wood/tile,
 /area/station/service/library)
-"csN" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
 "csP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -9871,10 +9943,12 @@
 /turf/open/floor/grass,
 /area/station/hallway/secondary/entry)
 "cuZ" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/light/cold/directional/south,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "cvf" = (
@@ -10231,8 +10305,17 @@
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port)
 "cBa" = (
-/turf/open/floor/iron/white,
-/area/station/command/heads_quarters/cmo)
+/obj/item/wheelchair{
+	pixel_y = -3
+	},
+/obj/item/wheelchair,
+/obj/item/wheelchair{
+	pixel_y = 3
+	},
+/obj/structure/table/glass,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/white/textured,
+/area/station/medical/storage)
 "cBb" = (
 /obj/effect/spawner/random/structure/chair_maintenance{
 	dir = 8
@@ -10281,12 +10364,12 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "cBF" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/effect/landmark/start/medical_doctor,
-/turf/open/floor/iron/dark,
-/area/station/medical/surgery/fore)
+/turf/open/floor/iron/white,
+/area/station/medical/storage)
 "cBP" = (
 /obj/effect/spawner/structure/window/hollow/plasma/middle{
 	dir = 4
@@ -10472,6 +10555,17 @@
 /obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"cDw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/aft)
 "cEb" = (
 /obj/effect/turf_decal/tile/green/half{
 	dir = 8
@@ -10857,7 +10951,7 @@
 /area/station/maintenance/floor3/port/aft)
 "cJj" = (
 /obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/dark,
 /area/station/medical/psychology)
 "cJt" = (
 /turf/open/floor/catwalk_floor/iron,
@@ -10932,6 +11026,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor2/port)
+"cKu" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/storage)
 "cKE" = (
 /obj/effect/turf_decal/trimline/purple/line{
 	dir = 1
@@ -11009,7 +11112,6 @@
 /area/station/command/heads_quarters/rd)
 "cLv" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/structure/extinguisher_cabinet/directional/south,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -11074,14 +11176,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor2/port)
-"cMi" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "cMm" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/catwalk_floor/iron_smooth,
@@ -11117,10 +11211,6 @@
 /obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/hallway/floor1/aft)
-"cNd" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/medical/medbay/lobby)
 "cNf" = (
 /obj/item/stack/tile/pod/light,
 /turf/open/floor/plating,
@@ -11261,19 +11351,15 @@
 /obj/structure/flora/bush/sparsegrass/style_random,
 /turf/open/floor/grass,
 /area/station/hallway/floor1/aft)
-"cPk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/sign/departments/chemistry/pharmacy/directional/south,
-/obj/effect/turf_decal/stripes/corner{
+"cPr" = (
+/obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/white/corner{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/side,
-/area/station/hallway/floor2/aft)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/white/herringbone,
+/area/station/medical/patients_rooms)
 "cPQ" = (
 /obj/structure/railing{
 	dir = 5
@@ -11297,12 +11383,26 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/floor3/aft)
+"cQe" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "cQg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
 /turf/open/floor/catwalk_floor,
 /area/station/science/cytology)
+"cQh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "cQj" = (
 /obj/effect/spawner/random/structure/chair_maintenance{
 	dir = 8
@@ -11357,12 +11457,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "cQN" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/effect/turf_decal/siding/white/end{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/turf/open/floor/iron/white/textured,
+/area/station/medical/cryo)
 "cQS" = (
 /obj/machinery/airalarm/directional/west,
 /obj/effect/turf_decal/stripes/line{
@@ -11625,14 +11725,12 @@
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor2/starboard)
 "cTP" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
+/obj/structure/sign/poster/official/random/directional/south,
 /turf/open/floor/iron/white,
-/area/station/medical/exam_room)
+/area/station/command/heads_quarters/cmo)
 "cTV" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
@@ -11670,17 +11768,6 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor2/port/fore)
-"cUm" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/structure/table/reinforced/rglass,
-/obj/item/storage/box/donkpockets,
-/turf/open/floor/wood/parquet,
-/area/station/medical/break_room)
 "cUq" = (
 /obj/structure/railing{
 	dir = 4
@@ -11767,6 +11854,9 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/chapel,
 /area/station/service/chapel)
+"cVs" = (
+/turf/closed/wall/r_wall,
+/area/station/medical/psychology)
 "cVt" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -11999,17 +12089,10 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
 "cXO" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/vending/wardrobe/medi_wardrobe,
+/turf/open/floor/iron/white/textured,
+/area/station/medical/storage)
 "cXP" = (
 /obj/machinery/telecomms/bus/preset_three,
 /turf/open/floor/circuit/telecomms,
@@ -12116,13 +12199,21 @@
 /obj/structure/sign/poster/official/random/directional/north,
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
-"cZu" = (
-/obj/machinery/light/cold/directional/east,
-/obj/effect/turf_decal/trimline/blue/arrow_cw{
-	dir = 8
+"cZo" = (
+/obj/effect/turf_decal/trimline/blue/warning{
+	dir = 5
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/obj/machinery/duct,
+/turf/open/floor/pod/dark,
+/area/station/maintenance/floor2/port)
+"cZu" = (
+/obj/effect/turf_decal/tile/blue/full,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/table/glass,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high,
+/turf/open/floor/iron/white/textured,
+/area/station/medical/treatment_center)
 "cZA" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
@@ -12283,11 +12374,25 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/wood,
 /area/station/hallway/floor4/fore)
+"dcd" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/iv_drip,
+/obj/structure/cable,
+/turf/open/floor/iron/white/herringbone,
+/area/station/medical/patients_rooms)
 "dch" = (
 /obj/machinery/light/directional/east,
 /obj/structure/sign/poster/random/directional/south,
 /turf/open/floor/carpet/purple,
 /area/station/commons/dorms/apartment1)
+"dco" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "dcp" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -12399,6 +12504,13 @@
 	initial_gas_mix = "TEMP=2.7"
 	},
 /area/station/science/ordnance/bomb)
+"ddS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/catwalk_floor,
+/area/station/maintenance/floor2/port)
 "ddT" = (
 /obj/structure/closet/radiation,
 /obj/effect/turf_decal/siding/thinplating_new/dark,
@@ -12461,6 +12573,12 @@
 "deM" = (
 /turf/open/floor/iron/white/textured_large,
 /area/station/service/chapel)
+"deP" = (
+/obj/machinery/computer/crew{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/cmo)
 "dfd" = (
 /obj/effect/turf_decal/trimline/blue/line,
 /obj/structure/cable,
@@ -12606,6 +12724,9 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor2/starboard)
+"dgR" = (
+/turf/closed/wall,
+/area/station/medical/paramedic)
 "dgU" = (
 /obj/structure/cable,
 /obj/machinery/light/red/dim/directional/north,
@@ -12722,19 +12843,18 @@
 /turf/open/floor/iron/white/small,
 /area/station/security/execution/education)
 "djj" = (
-/obj/effect/turf_decal/tile/blue/full,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/medical_kiosk,
-/turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
-"djo" = (
-/obj/machinery/microwave,
-/obj/effect/turf_decal/siding/wood/end{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
-/obj/structure/table/reinforced/rglass,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
+"djo" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/white,
-/area/station/medical/break_room)
+/area/station/command/heads_quarters/cmo)
 "djv" = (
 /obj/effect/landmark/start/research_director,
 /obj/effect/turf_decal/tile/purple/opposingcorners,
@@ -12793,18 +12913,14 @@
 /turf/open/floor/circuit/green,
 /area/station/science/server)
 "dkg" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/door/airlock/medical{
+	name = "Paramedic Dispatch"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/obj/effect/mapping_helpers/airlock/access/any/medical/general,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white/textured,
+/area/station/medical/paramedic)
 "dkh" = (
 /obj/machinery/camera/motion/directional/south{
 	name = "Minisat - Starboard";
@@ -12846,7 +12962,7 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/dark,
 /area/station/medical/psychology)
 "dla" = (
 /obj/effect/spawner/random/structure/girder,
@@ -12945,7 +13061,7 @@
 	},
 /area/station/cargo/office)
 "dnB" = (
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/dark,
 /area/station/medical/psychology)
 "dnI" = (
 /obj/structure/rack,
@@ -13082,8 +13198,8 @@
 /turf/open/floor/wood/tile,
 /area/station/service/library)
 "dpu" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
@@ -13261,12 +13377,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/engine,
 /area/station/maintenance/floor1/starboard/fore)
-"dru" = (
-/obj/effect/turf_decal/trimline/blue/corner{
-	dir = 4
-	},
-/turf/open/floor/pod/dark,
-/area/station/maintenance/floor2/port)
 "drA" = (
 /obj/effect/turf_decal/trimline/purple/line,
 /obj/structure/cable,
@@ -13322,11 +13432,6 @@
 /obj/item/wirerod,
 /turf/open/floor/plating,
 /area/station/maintenance/floor1/port/aft)
-"dst" = (
-/obj/structure/bookcase/random/reference,
-/obj/structure/sign/poster/official/random/directional/east,
-/turf/open/floor/carpet,
-/area/station/medical/psychology)
 "dsv" = (
 /obj/item/flamethrower,
 /turf/open/floor/iron,
@@ -13409,6 +13514,11 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor1/port/aft)
+"dtC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/stairs/south,
+/turf/open/floor/pod/dark,
+/area/station/maintenance/floor2/port)
 "dtI" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/glasses/welding,
@@ -13579,6 +13689,13 @@
 "dxd" = (
 /turf/open/floor/engine/o2,
 /area/station/engineering/atmos)
+"dxf" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/wood/parquet,
+/area/station/medical/break_room)
 "dxr" = (
 /obj/effect/spawner/random/trash/graffiti{
 	pixel_y = 32
@@ -13675,6 +13792,16 @@
 /obj/structure/grille,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port)
+"dye" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Elevator Shaft Access"
+	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/turf/open/floor/plating,
+/area/station/hallway/floor2/fore)
 "dyk" = (
 /obj/structure/transit_tube/station/dispenser{
 	dir = 8
@@ -13958,13 +14085,6 @@
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/floor4/aft)
-"dCp" = (
-/obj/structure/cable,
-/obj/machinery/light/cold/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "dCt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -14225,6 +14345,19 @@
 	dir = 4
 	},
 /area/station/service/hydroponics/garden)
+"dFI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "dFL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -14466,17 +14599,15 @@
 /turf/open/floor/plating,
 /area/station/service/bar/atrium)
 "dJj" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/station/medical/storage)
 "dJo" = (
 /obj/effect/landmark/navigate_destination/gateway,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -14600,8 +14731,13 @@
 /turf/open/floor/iron/dark,
 /area/station/command/teleporter)
 "dKI" = (
-/turf/closed/wall,
-/area/station/maintenance/department/medical)
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "dKJ" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -14632,6 +14768,7 @@
 "dLm" = (
 /obj/structure/weightmachine,
 /obj/effect/turf_decal/stripes,
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/smooth_large,
 /area/station/medical/psychology)
 "dLt" = (
@@ -14973,6 +15110,16 @@
 /obj/structure/flora/bush/sparsegrass/style_random,
 /turf/open/floor/grass,
 /area/station/medical/virology)
+"dPu" = (
+/obj/machinery/computer/operating{
+	dir = 1
+	},
+/obj/machinery/vending/wallmed/directional/south,
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/surgery/fore)
 "dPv" = (
 /obj/machinery/chem_master/condimaster{
 	desc = "Used to separate out liquids - useful for purifying botanical extracts. Also dispenses condiments.";
@@ -15081,13 +15228,6 @@
 /obj/effect/turf_decal/tile/green/full,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/storage/tech)
-"dQX" = (
-/obj/effect/spawner/structure/window/hollow/end{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/floor2/port)
 "dRb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/ash,
@@ -15095,13 +15235,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port/fore)
-"dRc" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/effect/turf_decal/trimline/blue/arrow_cw{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "dRf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -15513,17 +15646,10 @@
 /turf/open/floor/grass,
 /area/station/hallway/floor4/fore)
 "dWR" = (
-/obj/structure/bed{
-	dir = 4
-	},
-/obj/item/bedsheet/medical{
-	dir = 4
-	},
-/obj/structure/curtain/cloth,
-/obj/machinery/newscaster/directional/south,
-/obj/effect/landmark/start/medical_doctor,
+/obj/structure/closet/secure_closet/chief_medical,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/wood/parquet,
-/area/station/medical/exam_room)
+/area/station/command/heads_quarters/cmo)
 "dWT" = (
 /obj/effect/turf_decal/tile/green/fourcorners,
 /obj/effect/mapping_helpers/airlock/locked,
@@ -15576,12 +15702,13 @@
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port/fore)
 "dXt" = (
+/obj/structure/sign/departments/medbay/alt/directional/north,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
+	dir = 1
 	},
-/obj/machinery/newscaster/directional/north,
-/turf/open/floor/iron/dark,
-/area/station/command/heads_quarters/cmo)
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "dXy" = (
 /obj/effect/turf_decal/tile/blue/full,
 /obj/structure/closet/secure_closet/medical1,
@@ -15644,21 +15771,27 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor1/port/fore)
+"dYm" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/aft)
 "dYr" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/newscaster/directional/north,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal/incinerator)
-"dYv" = (
-/obj/effect/mapping_helpers/airlock/access/all/medical/cmo,
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical{
-	name = "CMO Office"
+"dYw" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/station/command/heads_quarters/cmo)
+/obj/structure/sign/poster/official/random/directional/west,
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/morgue)
 "dYx" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 8
@@ -15833,6 +15966,12 @@
 	},
 /turf/open/floor/engine/hull,
 /area/space/nearstation)
+"ebC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/command/heads_quarters/cmo)
 "ebE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -15888,15 +16027,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison)
-"ecx" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white/side{
-	dir = 8
-	},
-/area/station/medical/medbay/lobby)
 "ecB" = (
 /obj/structure/railing{
 	dir = 10
@@ -16058,6 +16188,15 @@
 /obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint)
+"eew" = (
+/obj/machinery/medical_kiosk,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/obj/machinery/camera/autoname/directional/south,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "eey" = (
 /obj/effect/spawner/random/structure/crate_abandoned,
 /obj/effect/turf_decal/bot,
@@ -16103,6 +16242,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/station/service/bar/atrium)
+"efm" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/white,
+/area/station/medical/abandoned)
 "efp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/depsec/engineering,
@@ -16513,6 +16656,11 @@
 /obj/item/circuitboard/machine/telecomms/processor,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
+"ekb" = (
+/obj/effect/spawner/random/structure/closet_maintenance,
+/obj/machinery/duct,
+/turf/open/floor/pod/dark,
+/area/station/maintenance/floor2/port)
 "ekj" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
@@ -16650,21 +16798,21 @@
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor2/port/fore)
 "elY" = (
-/obj/effect/turf_decal/trimline/green/line{
+/obj/effect/turf_decal/trimline/red/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/green/line{
+/obj/effect/turf_decal/trimline/red/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/green/mid_joiner{
+/obj/effect/turf_decal/trimline/red/mid_joiner{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/green/mid_joiner{
+/obj/effect/turf_decal/trimline/red/mid_joiner{
 	dir = 8
 	},
-/obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/poddoor/preopen{
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/poddoor{
 	elevator_linked_id = "com_vator";
 	elevator_mode = 1
 	},
@@ -16940,6 +17088,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"eop" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/left/directional/north{
+	name = "Pharmacy Desk";
+	req_access = list("pharmacy")
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/pharmacy)
 "eor" = (
 /obj/machinery/chem_dispenser,
 /obj/structure/sign/poster/official/periodic_table/directional/west,
@@ -17535,6 +17692,12 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/floor2/aft)
+"eyb" = (
+/obj/machinery/airalarm/directional/south,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/structure/closet/secure_closet/medical3,
+/turf/open/floor/iron/white/textured,
+/area/station/medical/storage)
 "eyo" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/trimline/blue/warning{
@@ -17701,14 +17864,6 @@
 	},
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor1/port/aft)
-"eAT" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/medical/exam_room)
 "eAV" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/blue/opposingcorners,
@@ -17788,20 +17943,13 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/commons/fitness)
 "eCi" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
 	},
-/obj/structure/sign/warning{
-	pixel_x = -32
+/obj/machinery/camera/autoname/directional/west,
+/obj/structure/sign/departments/psychology/directional/west{
+	name = "Asylum Entrance"
 	},
-/obj/machinery/door_buttons/access_button{
-	idDoor = "asylum_airlock_exterior";
-	name = "Asylum Access";
-	pixel_y = -26;
-	req_access = list("psychology")
-	},
-/obj/item/kirbyplants/random,
-/obj/machinery/light/cold/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "eCj" = (
@@ -17869,6 +18017,22 @@
 /obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/iron/dark,
 /area/station/medical/virology)
+"eDn" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/paramedic)
+"eDW" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "eEd" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Ancient Office"
@@ -17890,16 +18054,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/service/library/printer)
-"eEl" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/command/heads_quarters/cmo)
 "eEn" = (
 /obj/machinery/light/small/directional/west,
 /obj/structure/easel,
@@ -18011,10 +18165,24 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor3/starboard)
-"eFU" = (
-/obj/structure/disposalpipe/segment,
+"eFG" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/station/medical/office)
+"eFU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/medical/storage)
 "eFY" = (
 /turf/open/floor/plating,
 /area/station/maintenance/floor1/starboard)
@@ -18053,6 +18221,14 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/station/hallway/secondary/entry)
+"eGs" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white/herringbone,
+/area/station/medical/patients_rooms)
 "eGK" = (
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor4/starboard/fore)
@@ -18100,14 +18276,6 @@
 	dir = 5
 	},
 /area/station/hallway/floor4/fore)
-"eHv" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/structure/bed/dogbed/runtime,
-/mob/living/simple_animal/pet/cat/runtime,
-/turf/open/floor/carpet/royalblue,
-/area/station/command/heads_quarters/cmo)
 "eHD" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -18342,18 +18510,6 @@
 "eKC" = (
 /turf/closed/wall,
 /area/station/science/xenobiology/hallway)
-"eKJ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "eLd" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/dark/side{
@@ -18448,13 +18604,12 @@
 /turf/open/floor/grass,
 /area/station/service/library/garden)
 "eMA" = (
-/obj/structure/railing/corner{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/baseturf_helper/reinforced_plating/ceiling,
-/turf/open/floor/wood/parquet,
-/area/station/command/heads_quarters/cmo)
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "eMR" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
 /turf/open/floor/pod/light,
@@ -18495,6 +18650,12 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/pumproom)
+"eNn" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/station/hallway/floor2/fore)
 "eNo" = (
 /obj/machinery/camera/autoname/directional/south,
 /obj/structure/extinguisher_cabinet/directional/south,
@@ -18777,6 +18938,13 @@
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
+"eSK" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/obj/machinery/holopad,
+/turf/open/floor/iron/white/herringbone,
+/area/station/medical/patients_rooms)
 "eTa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -18792,6 +18960,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/floor3/starboard)
+"eTx" = (
+/obj/structure/closet/crate/bin{
+	name = "biowaste bin"
+	},
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron/white,
+/area/station/medical/surgery/aft)
 "eTH" = (
 /obj/structure/flora/bush/sparsegrass/style_random,
 /mob/living/carbon/human/species/monkey,
@@ -18911,6 +19086,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port)
+"eVB" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/pharmacy)
 "eVN" = (
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/dirt,
@@ -18922,9 +19102,13 @@
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor2/port)
 "eVU" = (
-/obj/structure/lattice/catwalk,
-/turf/open/openspace,
-/area/station/maintenance/floor2/port)
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/light/cold/directional/west,
+/obj/machinery/iv_drip,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/turf/open/floor/iron/white/herringbone,
+/area/station/medical/patients_rooms)
 "eVV" = (
 /obj/effect/landmark/start/chemist,
 /turf/open/floor/iron/white/small,
@@ -19137,13 +19321,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/chapel,
 /area/station/service/chapel)
-"eYT" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/structure/mannequin/skeleton,
-/turf/open/floor/iron/dark/textured,
-/area/station/medical/morgue)
 "eYY" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/built/directional/south,
@@ -19219,11 +19396,6 @@
 /obj/structure/closet/masks,
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor2/fore)
-"fak" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/holopad,
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
 "faq" = (
 /obj/effect/turf_decal/trimline/purple/end,
 /obj/machinery/shower/directional/south,
@@ -19305,6 +19477,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
+"faY" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/carpet/royalblue,
+/area/station/medical/break_room)
 "fbe" = (
 /obj/structure/disposalpipe/trunk/multiz/down{
 	dir = 1
@@ -19337,6 +19517,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"fbu" = (
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/white/textured,
+/area/station/medical/storage)
 "fbC" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -19367,13 +19551,6 @@
 /obj/structure/window/spawner/directional/south,
 /turf/open/floor/grass,
 /area/station/hallway/secondary/exit/departure_lounge)
-"fcc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/camera/autoname/directional/south,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/department/medical)
 "fce" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/structure/girder,
@@ -19408,6 +19585,15 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor2/starboard)
+"fcA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/office)
 "fcC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -19574,18 +19760,19 @@
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor1/port/fore)
 "ffM" = (
+/obj/structure/table/reinforced/rglass,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/left/directional/east{
+	name = "Paramedic's Desk";
+	req_access = list("medical")
+	},
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/effect/landmark/start/paramedic,
-/obj/structure/chair/office{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/item/stack/medical/suture,
+/obj/item/stack/medical/mesh,
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/medbay/lobby)
 "ffN" = (
 /obj/effect/turf_decal/tile/green/opposingcorners,
@@ -19619,11 +19806,12 @@
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
 "ffY" = (
-/obj/machinery/vending/snack/blue,
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/machinery/light/cold/directional/east,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/obj/effect/turf_decal/tile/blue/full,
+/obj/structure/sign/poster/official/random/directional/east,
+/obj/structure/table/glass,
+/obj/item/storage/box/bodybags,
+/turf/open/floor/iron/white/textured,
+/area/station/medical/treatment_center)
 "ffZ" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 5
@@ -19829,7 +20017,10 @@
 /turf/open/floor/wood,
 /area/station/hallway/secondary/entry)
 "fjm" = (
-/obj/structure/closet/emcloset,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "fjo" = (
@@ -20114,6 +20305,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hop)
+"fmB" = (
+/obj/structure/table/glass,
+/obj/item/modular_computer/laptop/preset/civilian,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/white/textured,
+/area/station/medical/office)
 "fmE" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/spawner/random/structure/tank_holder,
@@ -20258,12 +20455,7 @@
 /turf/open/floor/iron,
 /area/station/service/chapel)
 "fof" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "cmo_privacy";
-	name = "CMO Privacy Shutters"
-	},
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/cmo)
 "foh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -20355,6 +20547,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /turf/open/floor/plating,
 /area/station/hallway/floor1/aft)
+"fpB" = (
+/obj/structure/sink/directional/west,
+/obj/structure/sign/poster/official/random/directional/east,
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/surgery/fore)
 "fpD" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -20448,6 +20645,10 @@
 /obj/structure/sign/poster/random/directional/west,
 /turf/open/floor/catwalk_floor/iron,
 /area/station/cargo/miningdock)
+"fqY" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/station/medical/patients_rooms)
 "frz" = (
 /obj/effect/turf_decal/tile/green/opposingcorners,
 /obj/structure/rack,
@@ -20580,13 +20781,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
-"ftr" = (
-/obj/effect/mapping_helpers/airlock/access/any/medical/general,
-/obj/machinery/door/airlock/hatch{
-	name = "Maintenance Access"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/floor2/port)
 "ftu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -20681,8 +20875,9 @@
 	},
 /area/station/cargo/drone_bay)
 "fuY" = (
-/obj/machinery/chem_dispenser,
-/obj/structure/sign/poster/official/periodic_table/directional/east,
+/obj/structure/table/reinforced,
+/obj/item/book/manual/wiki/chemistry,
+/obj/item/hand_labeler,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/pharmacy)
 "fvb" = (
@@ -20785,10 +20980,13 @@
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
 "fwo" = (
-/obj/machinery/vending/cola/pwr_game,
-/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/light/cold/directional/east,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/medical/treatment_center)
 "fws" = (
 /obj/machinery/button/door/directional/north{
 	id = "radshutsouth"
@@ -20883,11 +21081,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"fxp" = (
-/obj/structure/dresser,
-/obj/machinery/light/warm/directional/north,
-/turf/open/floor/wood/parquet,
-/area/station/command/heads_quarters/cmo)
 "fxC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -21004,8 +21197,8 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "fzr" = (
@@ -21560,16 +21753,11 @@
 /turf/open/floor/plating,
 /area/station/hallway/floor4/aft)
 "fGI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/hatch{
-	name = "Maintenance Hatch"
+/obj/effect/turf_decal/siding/white{
+	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor2/port)
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/surgery/aft)
 "fGJ" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/pod/light,
@@ -21638,14 +21826,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/atmos/hfr_room)
-"fHo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/item/storage/box/rxglasses,
-/obj/structure/table/reinforced/rglass,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "fHy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -21851,6 +22031,16 @@
 "fKi" = (
 /turf/open/floor/iron/textured_large,
 /area/station/engineering/gravity_generator)
+"fKr" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id = "chem-lock-a";
+	name = "Chemistry Shutters"
+	},
+/turf/open/floor/plating,
+/area/station/medical/pharmacy)
 "fKs" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -21934,9 +22124,8 @@
 "fLv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "fLz" = (
@@ -22204,6 +22393,9 @@
 /obj/effect/spawner/random/engineering/tool,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port)
+"fPy" = (
+/turf/closed/wall/r_wall,
+/area/station/medical/pharmacy)
 "fPB" = (
 /obj/item/flashlight/lamp,
 /obj/structure/table,
@@ -22319,6 +22511,7 @@
 /turf/open/floor/iron/white/small,
 /area/station/medical/chemistry)
 "fQS" = (
+/obj/machinery/light/cold/no_nightlight/directional/east,
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/floor2/fore)
@@ -22364,10 +22557,6 @@
 "fRo" = (
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
-"fRp" = (
-/obj/effect/spawner/random/structure/girder,
-/turf/open/floor/plating,
-/area/station/maintenance/floor2/port)
 "fRv" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -22607,13 +22796,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
-"fUz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/light/red/dim/directional/west,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor2/port)
 "fUC" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer2{
 	dir = 5
@@ -22693,6 +22875,12 @@
 	name = "boxing ring"
 	},
 /area/station/commons/fitness)
+"fVP" = (
+/obj/structure/table/glass,
+/obj/item/storage/box/rxglasses,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/white/textured,
+/area/station/medical/storage)
 "fVT" = (
 /obj/machinery/computer/security,
 /obj/machinery/newscaster/directional/north,
@@ -23042,12 +23230,13 @@
 /turf/open/floor/plating,
 /area/station/security/warden)
 "gaG" = (
-/obj/machinery/light/cold/directional/east,
-/obj/effect/turf_decal/tile/blue/full,
-/obj/structure/table/glass,
-/obj/item/storage/box/hug/medical,
-/turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "gaH" = (
 /obj/structure/railing{
 	dir = 4
@@ -23180,6 +23369,13 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
+"gcn" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/aft)
 "gcs" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/effect/turf_decal/tile/green/half,
@@ -23426,6 +23622,13 @@
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics/garden)
+"gfL" = (
+/obj/machinery/firealarm/directional/east,
+/obj/structure/bodycontainer/morgue{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/morgue)
 "gfP" = (
 /obj/effect/turf_decal/siding/wood/end{
 	dir = 4
@@ -23583,6 +23786,9 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
+"gib" = (
+/turf/closed/wall/r_wall,
+/area/station/medical/treatment_center)
 "gid" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/random/trash/mess,
@@ -23681,12 +23887,6 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor2/fore)
-"gjA" = (
-/obj/structure/table/wood,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/item/storage/medkit/advanced,
-/turf/open/floor/wood/parquet,
-/area/station/command/heads_quarters/cmo)
 "gjC" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -23702,6 +23902,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/side,
 /area/station/security/prison)
+"gjN" = (
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/effect/landmark/start/medical_doctor,
+/obj/structure/chair/office/light,
+/turf/open/floor/iron/white/textured,
+/area/station/medical/office)
 "gjR" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/stripes{
@@ -23746,13 +23952,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "glg" = (
-/obj/structure/mirror/directional/south,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/machinery/camera/autoname/directional/south,
-/turf/open/floor/iron/white,
-/area/station/medical/exam_room)
+/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/storage)
 "gll" = (
 /obj/machinery/door/airlock/security{
 	name = "Storage"
@@ -23925,9 +24127,12 @@
 /turf/open/floor/carpet/neon/simple/pink/nodots,
 /area/station/maintenance/floor2/port/fore)
 "gnb" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/hedge,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron/white,
-/area/station/medical/exam_room)
+/area/station/command/heads_quarters/cmo)
 "gni" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/techstorage/arcade_boards,
@@ -24217,6 +24422,18 @@
 	},
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor1/port)
+"grK" = (
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/medical{
+	dir = 4
+	},
+/obj/structure/curtain/cloth,
+/obj/machinery/newscaster/directional/south,
+/obj/effect/landmark/start/medical_doctor,
+/turf/open/floor/wood/parquet,
+/area/station/medical/patients_rooms)
 "grW" = (
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -24338,6 +24555,10 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/security/evidence)
+"gtj" = (
+/obj/structure/grille,
+/turf/open/floor/pod/dark,
+/area/station/maintenance/floor3/port)
 "gts" = (
 /obj/item/rack_parts,
 /obj/item/weldingtool/mini,
@@ -24381,12 +24602,6 @@
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/atmos/pumproom)
-"gtR" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
 "gtX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -24403,6 +24618,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/psychologist,
+/obj/structure/sign/poster/official/random/directional/west,
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
 "guk" = (
@@ -24748,15 +24964,6 @@
 /obj/machinery/light/red/dim/directional/west,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor1/port/aft)
-"gyU" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/dead_body_placer,
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
 "gyV" = (
 /obj/machinery/atmospherics/components/unary/passive_vent{
 	name = "killroom vent"
@@ -24787,6 +24994,13 @@
 	dir = 1
 	},
 /area/station/hallway/floor3/fore)
+"gzo" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/machinery/iv_drip,
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "gzt" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark,
 /obj/machinery/light/small/directional/north,
@@ -24887,10 +25101,23 @@
 	},
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor3/starboard/fore)
+"gAz" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/grille/broken,
+/turf/open/floor/plating,
+/area/station/hallway/floor2/aft)
 "gAC" = (
 /obj/structure/sign/poster/official/random/directional/west,
 /turf/open/floor/wood/tile,
 /area/station/service/library)
+"gAE" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/medical/office)
 "gAP" = (
 /obj/item/reagent_containers/spray/syndicate,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -24946,6 +25173,20 @@
 /obj/effect/spawner/random/structure/closet_maintenance,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port)
+"gBE" = (
+/obj/item/healthanalyzer{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/cup/bottle/epinephrine{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/syringe,
+/obj/structure/table/glass,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/white/textured,
+/area/station/medical/office)
 "gBG" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
@@ -25179,12 +25420,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/floor2/port)
 "gFE" = (
-/obj/structure/closet/secure_closet/chief_medical,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/wood/parquet,
-/area/station/command/heads_quarters/cmo)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/firealarm/directional/south,
+/obj/machinery/light/cold/directional/south,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "gFO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -25336,6 +25579,15 @@
 /obj/structure/sign/warning/pods/directional/south,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor3/port/aft)
+"gHO" = (
+/obj/machinery/light/small/directional/north,
+/obj/structure/table/reinforced/rglass,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "gHU" = (
 /obj/structure/rack,
 /obj/item/storage/box/syringes,
@@ -25612,6 +25864,10 @@
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/iron,
 /area/station/hallway/floor3/fore)
+"gKT" = (
+/obj/structure/window/reinforced/spawner/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "gKV" = (
 /obj/machinery/light/red/dim/directional/east,
 /turf/open/floor/pod/dark,
@@ -25627,6 +25883,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/teleporter)
+"gLc" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/blood/old,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/table/optable{
+	desc = "A cold, hard place for your final rest.";
+	name = "Morgue Slab"
+	},
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "gLf" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
@@ -25681,12 +25948,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/sign/departments/chemistry/pharmacy/directional/south,
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/white/corner,
 /obj/machinery/door/airlock/public/glass{
 	name = "Public Airlock"
 	},
-/turf/open/floor/iron/dark/side{
-	dir = 10
-	},
+/turf/open/floor/iron/dark/side,
 /area/station/hallway/floor2/aft)
 "gMd" = (
 /obj/effect/turf_decal/trimline/blue/line{
@@ -25808,14 +26076,17 @@
 /turf/open/floor/fakebasalt,
 /area/station/maintenance/floor3/port)
 "gNT" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
-/obj/structure/sign/departments/psychology/directional/west,
-/turf/open/floor/iron/white,
+/obj/item/radio/intercom/directional/west,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/medbay/central)
 "gOd" = (
 /obj/effect/turf_decal/bot,
@@ -25963,6 +26234,15 @@
 /obj/structure/sign/poster/official/random/directional/south,
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/floor2/fore)
+"gQh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/medical/storage)
 "gQA" = (
 /obj/structure/railing{
 	dir = 1
@@ -26476,8 +26756,12 @@
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "gXY" = (
-/turf/closed/wall,
-/area/station/medical/exam_room)
+/obj/item/flashlight/lamp/green,
+/obj/structure/table/wood,
+/obj/item/instrument/guitar,
+/obj/machinery/duct,
+/turf/open/floor/wood/parquet,
+/area/station/command/heads_quarters/cmo)
 "gYb" = (
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
@@ -26779,14 +27063,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
-"hbT" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/machinery/light/cold/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/medical/pharmacy)
 "hbW" = (
 /obj/structure/railing{
 	layer = 3.1
@@ -26843,6 +27119,26 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/side,
 /area/station/commons/locker)
+"hcP" = (
+/obj/item/storage/backpack/duffelbag/med/surgery{
+	pixel_y = 13
+	},
+/obj/item/reagent_containers/medigel/sterilizine{
+	pixel_x = 1
+	},
+/obj/item/reagent_containers/syringe{
+	pixel_x = -7
+	},
+/obj/item/stack/medical/bone_gel{
+	pixel_x = 10
+	},
+/obj/effect/turf_decal/box/white,
+/obj/structure/table/reinforced/rglass,
+/obj/effect/turf_decal/siding/white{
+	dir = 9
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/surgery/aft)
 "hcR" = (
 /obj/structure/ladder,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -26860,6 +27156,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/break_room)
 "hdg" = (
@@ -26961,6 +27258,11 @@
 	},
 /turf/open/floor/carpet/red,
 /area/station/service/library/artgallery)
+"hdP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "hdS" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -27267,17 +27569,6 @@
 	dir = 9
 	},
 /area/station/security/prison)
-"hhR" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Medical Front Desk"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/medical/general,
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
 "hhX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -27455,6 +27746,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/lab)
+"hkU" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/obj/machinery/light/cold/directional/north,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "hkZ" = (
 /obj/machinery/door/airlock{
 	name = "Service Hall"
@@ -27480,6 +27779,15 @@
 /obj/effect/turf_decal/tile/green/full,
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
+"hls" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "hlG" = (
 /obj/structure/closet/mini_fridge{
 	desc = "A small contraption designed to imbue a few drinks with a pleasant chill.";
@@ -27529,14 +27837,16 @@
 /turf/open/floor/iron/dark,
 /area/station/commons/storage/primary)
 "hmk" = (
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/station/command/heads_quarters/cmo)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/medbay/central)
 "hmn" = (
 /obj/effect/turf_decal/siding/thinplating_new{
 	dir = 4
@@ -27836,6 +28146,13 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/floor3/fore)
+"hpG" = (
+/obj/structure/cable,
+/obj/machinery/computer/operating{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "hpI" = (
 /turf/closed/wall,
 /area/station/commons/fitness/recreation)
@@ -28008,6 +28325,17 @@
 /obj/effect/spawner/random/trash/bucket,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor2/port/aft)
+"hsL" = (
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/mail_sorting/medbay/chemistry,
+/obj/effect/mapping_helpers/mail_sorting/medbay/cmo_office,
+/obj/effect/mapping_helpers/mail_sorting/medbay/general,
+/obj/effect/mapping_helpers/mail_sorting/medbay/virology,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/dark/side,
+/area/station/hallway/floor2/aft)
 "hsT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/spawner/structure/window/hollow/plasma/middle,
@@ -28256,6 +28584,14 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor1/port/fore)
+"hvG" = (
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/public/glass{
+	name = "Medbay Lobby"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/medbay/lobby)
 "hvN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -28477,7 +28813,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/dark,
 /area/station/medical/psychology)
 "hyW" = (
 /obj/structure/table,
@@ -28690,6 +29026,13 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor2/port/aft)
+"hBP" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor,
+/area/station/maintenance/floor3/port/aft)
 "hBR" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/broken/directional/north,
@@ -28758,6 +29101,12 @@
 /obj/structure/table,
 /turf/open/floor/iron/dark,
 /area/station/commons/storage/primary)
+"hCW" = (
+/obj/structure/closet/secure_closet/medical2,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/structure/sign/poster/official/random/directional/south,
+/turf/open/floor/iron/white,
+/area/station/medical/surgery/aft)
 "hDa" = (
 /obj/effect/turf_decal/stripes,
 /turf/open/floor/plating/elevatorshaft,
@@ -28784,7 +29133,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 1;
-	id = "chem-lockdown";
+	id = "chem-lock-f";
 	name = "Chemistry Shutters"
 	},
 /turf/open/floor/plating,
@@ -29268,6 +29617,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "hKN" = (
@@ -29338,6 +29688,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/floor2/fore)
+"hLw" = (
+/obj/structure/sign/poster/official/random/directional/north,
+/turf/open/floor/carpet,
+/area/station/medical/psychology)
 "hLy" = (
 /turf/open/floor/plating/reinforced{
 	initial_gas_mix = "TEMP=2.7"
@@ -29352,14 +29706,6 @@
 /obj/structure/cable,
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor2/port/aft)
-"hLJ" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/structure/sign/poster/official/moth_meth/directional/south,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/medical/pharmacy)
 "hLL" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
@@ -29521,11 +29867,14 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "hNK" = (
+/obj/structure/table/wood,
+/obj/machinery/fax{
+	fax_name = "Psychology Office";
+	name = "Psychology Office Fax Machine"
+	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/obj/machinery/light/warm/directional/north,
-/obj/structure/sign/poster/official/random/directional/north,
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
 "hNU" = (
@@ -29566,6 +29915,9 @@
 /obj/machinery/meter,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"hOA" = (
+/turf/closed/wall/r_wall,
+/area/station/maintenance/floor2/port/fore)
 "hOF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -29632,14 +29984,11 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "hQl" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/structure/cable,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 1;
-	id = "chem-lockdown";
-	name = "Chemistry Shutters"
-	},
-/turf/open/floor/plating,
+/obj/machinery/vending/wardrobe/chem_wardrobe,
+/obj/structure/sign/poster/official/plasma_effects/directional/west,
+/turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "hQp" = (
 /obj/structure/girder/reinforced,
@@ -29752,6 +30101,18 @@
 	dir = 4
 	},
 /area/station/security/prison)
+"hRL" = (
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/medical{
+	dir = 4
+	},
+/obj/structure/curtain/cloth,
+/obj/machinery/newscaster/directional/north,
+/obj/effect/landmark/start/medical_doctor,
+/turf/open/floor/wood/parquet,
+/area/station/medical/patients_rooms)
 "hRO" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/junction{
@@ -29806,12 +30167,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
-"hSC" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/wood/parquet,
-/area/station/command/heads_quarters/cmo)
 "hSH" = (
 /obj/machinery/door/airlock{
 	id_tag = "CabinS";
@@ -29879,9 +30234,12 @@
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor4/starboard/fore)
 "hTs" = (
-/obj/effect/landmark/start/depsec/medical,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/machinery/light/cold/directional/south,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/medical/paramedic)
 "hTu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -29955,6 +30313,11 @@
 	},
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/floor1/aft)
+"hUL" = (
+/obj/structure/cable/multilayer/multiz,
+/obj/structure/lattice/catwalk,
+/turf/open/openspace,
+/area/station/maintenance/floor3/port/aft)
 "hUN" = (
 /obj/machinery/mineral/stacking_machine{
 	input_dir = 2
@@ -30079,12 +30442,39 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/station/maintenance/floor4/starboard)
+"hWv" = (
+/obj/effect/turf_decal/trimline/blue/warning{
+	dir = 1
+	},
+/obj/effect/spawner/random/structure/tank_holder,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/pod/dark,
+/area/station/maintenance/floor2/port)
 "hWx" = (
 /obj/structure/railing{
 	dir = 4
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/hallway/floor2/aft)
+"hWz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/effect/mapping_helpers/airlock/access/any/medical/general,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Medbay Hall"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/white/textured,
+/area/station/medical/medbay/central)
 "hWB" = (
 /obj/structure/showcase/cyborg/old{
 	dir = 4;
@@ -30132,13 +30522,18 @@
 /turf/open/floor/wood,
 /area/station/commons/dorms/apartment2)
 "hWT" = (
-/obj/structure/table/reinforced/rglass,
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/item/storage/medkit/regular,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/start/paramedic,
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/paramedic)
 "hWV" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -30247,6 +30642,13 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor1/port)
+"hYS" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/obj/structure/sink/kitchen/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "hYT" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/effect/landmark/start/depsec/supply,
@@ -30351,6 +30753,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/commons/dorms/room4)
+"iaG" = (
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/wood/parquet,
+/area/station/medical/psychology)
 "iaJ" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance/two,
@@ -30393,15 +30799,6 @@
 "ibz" = (
 /turf/open/openspace,
 /area/station/science/cytology)
-"ibC" = (
-/obj/structure/table,
-/obj/effect/turf_decal/siding/white,
-/obj/item/folder/white,
-/obj/machinery/camera/autoname/directional/north,
-/obj/machinery/newscaster/directional/north,
-/obj/item/paper_bin,
-/turf/open/floor/iron/dark,
-/area/station/medical/medbay/lobby)
 "ibE" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
@@ -30494,7 +30891,8 @@
 /area/station/maintenance/floor2/starboard/fore)
 "icF" = (
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/white,
 /area/station/medical/abandoned)
 "icY" = (
 /obj/structure/cable/multilayer/multiz,
@@ -30652,6 +31050,16 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/floor3/starboard)
+"ifp" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id = "cmo_privacy";
+	name = "CMO Privacy Shutters"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/command/heads_quarters/cmo)
 "ift" = (
 /obj/structure/closet/wardrobe/white,
 /obj/item/radio/intercom/directional/east,
@@ -30682,6 +31090,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/circuits)
+"ifC" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/machinery/newscaster/directional/north,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/cmo)
 "ifG" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/dark/side{
@@ -30756,12 +31173,6 @@
 	},
 /turf/open/floor/wood/tile,
 /area/station/service/library/lounge)
-"igS" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/co2{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/medical/cryo)
 "igX" = (
 /obj/machinery/light/cold/directional/north,
 /obj/machinery/keycard_auth/directional/north{
@@ -30778,7 +31189,10 @@
 /area/station/command/heads_quarters/cmo)
 "ihg" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/toy/plush/lizard_plushie/green,
+/obj/item/toy/plush/lizard_plushie/green{
+	name = "Bites-The-Wires";
+	desc = "A stuffed toy which resembles a wayward Ashlander. This one fills you with hope for the future."
+	},
 /obj/effect/turf_decal/trimline/green/line{
 	dir = 10
 	},
@@ -31015,6 +31429,9 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/abandoned)
+"ikl" = (
+/turf/closed/wall,
+/area/station/medical/patients_rooms)
 "ikn" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -31181,11 +31598,19 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
 "imi" = (
-/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/iron/dark/textured,
-/area/station/medical/cryo)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "imj" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
@@ -31240,6 +31665,18 @@
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai)
+"imU" = (
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/iron/white/textured,
+/area/station/medical/office)
+"imW" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/medical/medbay/aft)
 "imY" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -31297,15 +31734,15 @@
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
 "inQ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 1
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/door/airlock/medical{
+	name = "Cryogenics"
 	},
+/obj/effect/mapping_helpers/airlock/access/any/medical/general,
+/obj/machinery/door/firedoor,
 /obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/turf/open/floor/iron/white/textured,
+/area/station/medical/treatment_center)
 "inR" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 10
@@ -31410,11 +31847,9 @@
 /turf/open/floor/plating,
 /area/station/security/prison)
 "ipA" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/station/medical/medbay/lobby)
 "ipB" = (
 /obj/structure/sign/poster/official/random/directional/north,
 /obj/effect/landmark/start/medical_doctor,
@@ -31452,19 +31887,12 @@
 /turf/open/floor/iron/dark,
 /area/station/security/eva)
 "iqj" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/white{
 	dir = 1
 	},
-/obj/machinery/requests_console/directional/south{
-	department = "Medbay";
-	name = "Medbay Requests Console"
-	},
-/obj/effect/mapping_helpers/requests_console/supplies,
-/obj/effect/mapping_helpers/requests_console/assistance,
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/structure/closet/secure_closet/medical3,
-/turf/open/floor/iron/white,
-/area/station/medical/storage)
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/surgery/fore)
 "iqt" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -31522,6 +31950,14 @@
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor4/starboard/fore)
+"iqJ" = (
+/obj/machinery/camera/autoname/directional/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/structure/mannequin/skeleton,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "iqR" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -31559,6 +31995,16 @@
 /obj/effect/baseturf_helper/reinforced_plating/ceiling,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
+"irr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/aft)
 "irK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -31691,9 +32137,9 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/second)
 "itp" = (
-/obj/machinery/camera/autoname/directional/south,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/disposalpipe/junction/flip{
+	dir = 8
 	},
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/floor2/aft)
@@ -31753,6 +32199,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
+"iul" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "chem-lock-a";
+	name = "Chemistry Shutters"
+	},
+/turf/open/floor/plating,
+/area/station/medical/pharmacy)
 "iun" = (
 /obj/effect/mapping_helpers/airlock/access/all/medical/chemistry,
 /obj/machinery/door/airlock/hatch{
@@ -31877,6 +32333,19 @@
 "ivL" = (
 /turf/closed/wall,
 /area/station/medical/surgery/aft)
+"ivM" = (
+/obj/machinery/door/airlock/medical{
+	name = "Morgue"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/any/medical/morgue,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/medical/morgue)
 "ivQ" = (
 /obj/machinery/light/red/dim/directional/west,
 /turf/open/floor/iron/dark,
@@ -32300,6 +32769,11 @@
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor2/port/fore)
+"iCb" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "iCh" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/newscaster/directional/south,
@@ -32456,6 +32930,10 @@
 	},
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor3/starboard)
+"iFi" = (
+/obj/machinery/light/small/directional/south,
+/turf/closed/wall,
+/area/station/medical/paramedic)
 "iFo" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/mix_output,
 /obj/effect/turf_decal/trimline/brown/line,
@@ -32467,6 +32945,15 @@
 /obj/effect/spawner/random/maintenance/four,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor2/port)
+"iFt" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "iFu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -32549,6 +33036,17 @@
 	dir = 8
 	},
 /area/station/security/office)
+"iGC" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/obj/machinery/duct,
+/obj/effect/landmark/start/medical_doctor,
+/turf/open/floor/iron/white,
+/area/station/medical/office)
 "iGG" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -32596,13 +33094,6 @@
 	},
 /turf/open/floor/engine/airless,
 /area/station/engineering/atmos/pumproom)
-"iHc" = (
-/obj/effect/turf_decal/trimline/blue/warning{
-	dir = 4
-	},
-/obj/effect/spawner/random/engineering/atmospherics_portable,
-/turf/open/floor/pod/dark,
-/area/station/maintenance/floor2/port)
 "iHk" = (
 /turf/open/floor/catwalk_floor,
 /area/station/hallway/floor1/fore)
@@ -32678,6 +33169,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor1/fore)
+"iIh" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/office)
 "iIm" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Maintenance Hatch"
@@ -32774,15 +33271,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"iJK" = (
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/structure/chair/comfy/teal{
-	dir = 4
-	},
-/obj/effect/landmark/start/paramedic,
-/obj/item/radio/intercom/directional/west,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
 "iJM" = (
 /obj/machinery/computer/monitor{
 	dir = 4;
@@ -33193,6 +33681,9 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/floor3/starboard)
+"iPc" = (
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "iPm" = (
 /obj/machinery/food_cart,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
@@ -33213,13 +33704,20 @@
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor4/starboard)
 "iPE" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/effect/mapping_helpers/airlock/access/any/medical/general,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/unres{
 	dir = 4
 	},
-/turf/open/floor/iron/dark/textured,
-/area/station/medical/morgue)
+/obj/machinery/door/airlock/medical/glass{
+	name = "Treatment Center"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "iPH" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Permabrig - Isolation A";
@@ -33328,16 +33826,8 @@
 /turf/open/floor/iron/dark/side,
 /area/station/commons/locker)
 "iQL" = (
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/machinery/light/cold/directional/north,
-/obj/item/storage/box/rxglasses,
-/obj/structure/table/glass,
-/obj/item/storage/box/gloves{
-	pixel_x = 3;
-	pixel_y = 4
-	},
-/turf/open/floor/iron/white/textured,
-/area/station/medical/medbay/central)
+/turf/open/floor/wood/parquet,
+/area/station/command/heads_quarters/cmo)
 "iQU" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -33388,6 +33878,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/science/lab)
+"iRF" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white/herringbone,
+/area/station/medical/patients_rooms)
 "iRK" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -33564,6 +34063,15 @@
 /obj/effect/mapping_helpers/requests_console/assistance,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
+"iTW" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/duct,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/white/textured,
+/area/station/medical/storage)
 "iTX" = (
 /obj/machinery/light_switch/directional/north,
 /obj/structure/disposalpipe/segment{
@@ -33758,11 +34266,18 @@
 "iXb" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/structure/cable,
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/button/door/directional/east{
-	id = "chem-lock";
-	name = "Chemistry Lockdown"
+	id = "chem-lock-f";
+	name = "Chemistry Fore Lockdown";
+	pixel_y = 5;
+	req_access = list("pharmacy")
+	},
+/obj/machinery/button/door/directional/east{
+	id = "chem-lock-a";
+	name = "Chemistry Aft Lockdown";
+	pixel_y = -4;
+	req_access = list("pharmacy")
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
@@ -33910,16 +34425,12 @@
 	},
 /area/station/hallway/floor3/fore)
 "iYX" = (
-/obj/effect/turf_decal/trimline/blue/arrow_cw{
-	dir = 1
-	},
-/obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
-"iZe" = (
-/obj/machinery/newscaster/directional/south,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/obj/machinery/cell_charger,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/structure/table/glass,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/white/textured,
+/area/station/medical/storage)
 "iZh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -34767,15 +35278,17 @@
 /turf/open/floor/iron/textured,
 /area/station/cargo/storage)
 "jmr" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/arrow_cw{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/machinery/duct,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/station/medical/storage)
 "jmu" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
@@ -34844,14 +35357,6 @@
 	},
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor3/starboard)
-"jmZ" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/iron/stairs/right{
-	dir = 1
-	},
-/area/station/command/heads_quarters/cmo)
 "jnh" = (
 /turf/open/floor/iron/dark/side,
 /area/station/commons/locker)
@@ -34909,6 +35414,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/lab)
+"joc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/sign/departments/medbay/alt/directional/south,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/dark/side,
+/area/station/hallway/floor2/aft)
 "joh" = (
 /obj/machinery/shower/directional/west,
 /turf/open/floor/iron/freezer,
@@ -35058,6 +35571,19 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/catwalk_floor/iron,
 /area/station/engineering/atmos/office)
+"jpL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/chair/sofa/bench/solo,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "jpM" = (
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 1
@@ -35118,10 +35644,13 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/first)
 "jqH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/item/radio/intercom/directional/west,
-/turf/open/floor/wood/parquet,
-/area/station/command/heads_quarters/cmo)
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/structure/closet/l3closet/virology,
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "jqJ" = (
 /turf/open/floor/plating/foam,
 /area/station/maintenance/floor2/port)
@@ -35196,18 +35725,6 @@
 /obj/effect/spawner/random/structure/grille,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor3/starboard/aft)
-"jrP" = (
-/obj/machinery/door/airlock/medical{
-	name = "Operating Room B"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/medical/surgery,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/turf/open/floor/iron/white,
-/area/station/medical/surgery/aft)
 "jrV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -35411,9 +35928,14 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison)
 "juM" = (
-/obj/structure/cable,
-/obj/structure/sign/warning/no_smoking/circle/directional/east,
-/turf/open/floor/iron/white,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/duct,
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/medbay/central)
 "juW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -35527,10 +36049,6 @@
 	dir = 1
 	},
 /area/station/hallway/floor3/fore)
-"jww" = (
-/obj/structure/industrial_lift/public,
-/turf/open/floor/plating/elevatorshaft,
-/area/station/hallway/floor3/fore)
 "jwG" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -35543,12 +36061,13 @@
 	},
 /area/station/security/brig)
 "jwH" = (
-/obj/effect/turf_decal/tile/blue/full,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/dead_body_placer,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/structure/table/glass,
-/turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "jwP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -35571,6 +36090,7 @@
 /obj/effect/turf_decal/trimline/yellow/corner{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron/white,
 /area/station/medical/abandoned)
 "jwY" = (
@@ -35607,6 +36127,17 @@
 /obj/structure/sign/departments/telecomms/directional/south,
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/floor1/aft)
+"jxn" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/wideplating,
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/medbay/central)
 "jxy" = (
 /obj/structure/table,
 /obj/item/taperecorder/empty{
@@ -35703,10 +36234,6 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port/fore)
-"jyd" = (
-/obj/structure/sink/directional/west,
-/turf/open/floor/iron/dark,
-/area/station/medical/surgery/aft)
 "jye" = (
 /obj/structure/table,
 /obj/item/clothing/glasses/sunglasses{
@@ -35719,6 +36246,13 @@
 /obj/machinery/recharger,
 /turf/open/floor/iron/dark,
 /area/station/security/range)
+"jyk" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "jyp" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Head of Security Office"
@@ -35970,9 +36504,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "jAZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/door/airlock/hatch{
 	name = "Maintenance Access"
 	},
@@ -36014,11 +36545,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/floor2/port)
-"jCc" = (
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/structure/hedge,
-/turf/open/floor/iron/white,
-/area/station/command/heads_quarters/cmo)
 "jCi" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor/heavy,
@@ -36337,6 +36863,11 @@
 /obj/structure/grille,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/starboard)
+"jFV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron/white/herringbone,
+/area/station/medical/patients_rooms)
 "jFZ" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
@@ -36398,14 +36929,6 @@
 	},
 /turf/open/floor/iron/dark/smooth_corner,
 /area/station/engineering/storage/tech)
-"jGO" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/obj/machinery/iv_drip,
-/obj/structure/sign/poster/official/random/directional/south,
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
 "jHc" = (
 /obj/machinery/door/window/left/directional/north{
 	name = "Telecomms Cooling";
@@ -36594,9 +37117,11 @@
 	},
 /area/station/security/checkpoint)
 "jJf" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/suit_storage_unit/medical,
+/obj/structure/sign/poster/official/cleanliness/directional/east,
+/turf/open/floor/iron/white/textured,
+/area/station/medical/storage)
 "jJm" = (
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor1/starboard)
@@ -36658,14 +37183,12 @@
 /turf/open/floor/engine,
 /area/station/maintenance/floor1/port/aft)
 "jKf" = (
-/obj/machinery/vending/wallmed/directional/west,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/rnd/production/techfab/department/medical,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
-/area/station/medical/storage)
+/area/station/medical/office)
 "jKh" = (
 /obj/structure/closet/cabinet,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -36857,14 +37380,6 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor3/port/aft)
-"jNh" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/machinery/airalarm/directional/south,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/medical/pharmacy)
 "jNp" = (
 /obj/machinery/disposal/bin{
 	name = "Book Returns"
@@ -36973,27 +37488,6 @@
 /obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
-"jOB" = (
-/obj/item/storage/medkit/o2{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/storage/medkit/o2,
-/obj/item/storage/medkit/o2{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/item/storage/medkit/regular,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/window/left/directional/south{
-	name = "First Aid Supplies";
-	req_access = list("medical")
-	},
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/turf/open/floor/iron/white,
-/area/station/medical/storage)
 "jOC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -37143,18 +37637,24 @@
 	},
 /area/station/medical/chemistry)
 "jQj" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/effect/turf_decal/trimline/blue/arrow_cw{
-	dir = 1
-	},
-/obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/suit_storage_unit/medical,
+/obj/machinery/camera/autoname/directional/east,
+/turf/open/floor/iron/white/textured,
+/area/station/medical/storage)
 "jQw" = (
 /turf/open/floor/iron/dark/textured_corner{
 	dir = 8
 	},
 /area/station/maintenance/floor1/starboard/aft)
+"jQx" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Elevator Shaft Access"
+	},
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/turf/open/floor/plating,
+/area/station/hallway/floor2/aft)
 "jQG" = (
 /obj/structure/railing,
 /obj/effect/decal/cleanable/dirt,
@@ -37333,7 +37833,7 @@
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
 "jSw" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/medical/pharmacy)
 "jSy" = (
@@ -37393,6 +37893,14 @@
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/carpet/red,
 /area/station/service/theater)
+"jTA" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/newscaster/directional/north,
+/obj/machinery/light/warm/directional/north,
+/turf/open/floor/carpet,
+/area/station/medical/psychology)
 "jTE" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/sign/departments/medbay/alt/directional/south,
@@ -37415,6 +37923,10 @@
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/wood,
 /area/station/service/bar)
+"jTW" = (
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/grass,
+/area/station/medical/medbay/lobby)
 "jUf" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor/heavy,
@@ -37496,10 +38008,9 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "jVs" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/turf/open/floor/iron/white,
-/area/station/medical/storage)
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/station/medical/cryo)
 "jVu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -37530,14 +38041,14 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor3/fore)
 "jVQ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/duct,
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/turf/open/floor/iron/white,
-/area/station/medical/storage)
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/white,
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/cryo)
 "jVS" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/delivery,
@@ -37593,12 +38104,11 @@
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor2/port/fore)
 "jWt" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal/bin,
-/obj/machinery/light/cold/directional/north,
+/obj/structure/sign/departments/psychology/directional/west,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "jWJ" = (
@@ -37621,7 +38131,15 @@
 /area/station/service/kitchen/diner)
 "jWV" = (
 /obj/structure/cable,
-/obj/machinery/camera/autoname/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 1
+	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "jXb" = (
@@ -37723,10 +38241,26 @@
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor1/starboard/aft)
 "jZe" = (
-/obj/structure/closet/crate/freezer/surplus_limbs,
+/obj/item/storage/medkit/fire{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/storage/medkit/fire,
+/obj/item/storage/medkit/fire{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/blue/fourcorners,
-/turf/open/floor/iron/white,
-/area/station/medical/surgery/fore)
+/obj/item/storage/medkit/regular,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/machinery/door/window/right/directional/east{
+	name = "First Aid Supplies";
+	req_access = list("medical")
+	},
+/obj/structure/sign/poster/official/random/directional/west,
+/turf/open/floor/iron/white/textured,
+/area/station/medical/storage)
 "jZj" = (
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor1/port)
@@ -37753,15 +38287,37 @@
 	dir = 1
 	},
 /area/station/hallway/floor1/fore)
+"jZD" = (
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/effect/mapping_helpers/airlock/access/any/medical/general,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Aft Medbay"
+	},
+/obj/machinery/duct,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/aft)
 "jZE" = (
 /obj/machinery/vending/clothing,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "jZF" = (
-/obj/machinery/camera/autoname/directional/west,
-/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/airalarm/directional/south,
+/obj/machinery/light/cold/directional/south,
 /turf/open/floor/iron/white,
-/area/station/medical/storage)
+/area/station/medical/office)
 "jZL" = (
 /obj/structure/cable,
 /turf/open/floor/carpet,
@@ -38307,6 +38863,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/floor1/aft)
+"kfN" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/machinery/duct,
+/obj/machinery/camera/autoname/directional/north,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/aft)
 "kga" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -38317,6 +38883,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"kgu" = (
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Triage"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/medical/general,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white/textured,
+/area/station/medical/office)
 "kgK" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -38500,6 +39080,17 @@
 /obj/machinery/light/cold/no_nightlight/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"kiF" = (
+/obj/structure/railing,
+/obj/structure/chair/sofa/bench/solo{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "kiM" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -38512,7 +39103,7 @@
 	dir = 10
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
+/turf/open/floor/iron/white,
 /area/station/medical/abandoned)
 "kjb" = (
 /obj/effect/decal/cleanable/blood/splatter,
@@ -38577,16 +39168,23 @@
 /turf/open/floor/iron,
 /area/station/hallway/floor3/aft)
 "kkj" = (
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/structure/table/glass,
-/obj/item/storage/box/masks,
-/obj/item/storage/box/bodybags{
-	pixel_x = 4;
-	pixel_y = 4
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/effect/turf_decal/siding/white,
+/obj/structure/cable,
+/obj/structure/table/reinforced/rglass,
+/obj/item/reagent_containers/cup/beaker/cryoxadone{
+	pixel_x = 6;
+	pixel_y = 6
 	},
-/obj/structure/sign/departments/medbay/alt/directional/south,
-/turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/obj/item/storage/pill_bottle/mannitol,
+/obj/item/reagent_containers/cup/beaker/cryoxadone{
+	pixel_x = -6;
+	pixel_y = 10
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/cryo)
 "kkr" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/random/entertainment/cigar,
@@ -38614,14 +39212,10 @@
 /turf/open/floor/carpet/orange,
 /area/station/service/chapel/funeral)
 "kkF" = (
-/obj/machinery/light/cold/directional/south,
-/obj/effect/turf_decal/trimline/blue/arrow_cw{
-	dir = 1
-	},
-/obj/structure/sign/warning/no_smoking/circle/directional/south,
-/obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/cryo)
 "kkI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -38753,13 +39347,11 @@
 /turf/closed/wall,
 /area/station/science/lab)
 "kmT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
+	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/storage)
+/area/station/medical/medbay/aft)
 "knf" = (
 /obj/effect/turf_decal/trimline/brown/line{
 	dir = 4
@@ -38779,7 +39371,8 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/white,
 /area/station/medical/abandoned)
 "knk" = (
 /obj/structure/railing{
@@ -39125,11 +39718,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/checker,
 /area/station/commons/vacant_room/commissary)
-"krA" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/turf/open/floor/pod/light,
-/area/station/maintenance/department/medical)
 "krF" = (
 /obj/machinery/door/airlock/external{
 	name = "External Airlock"
@@ -39305,9 +39893,9 @@
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology/hallway)
 "ktL" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 8
-	},
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/carpet/royalblue,
 /area/station/medical/break_room)
 "ktN" = (
@@ -39317,14 +39905,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
-"ktT" = (
-/obj/structure/cable,
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
 "ktV" = (
 /obj/structure/moisture_trap,
 /turf/open/floor/pod/light,
@@ -39385,17 +39965,12 @@
 /turf/open/floor/plating/foam,
 /area/station/maintenance/floor1/port/aft)
 "kuX" = (
+/obj/item/bedsheet/cmo/double,
+/obj/structure/bed/double,
+/obj/effect/landmark/start/chief_medical_officer,
 /obj/effect/turf_decal/siding/wood,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/exam_room)
-"kva" = (
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/machinery/vending/wardrobe/medi_wardrobe,
-/turf/open/floor/iron/white,
-/area/station/medical/storage)
+/turf/open/floor/carpet/royalblue,
+/area/station/command/heads_quarters/cmo)
 "kvi" = (
 /obj/effect/mapping_helpers/airlock/access/any/security/court,
 /obj/machinery/door/firedoor,
@@ -39422,13 +39997,6 @@
 /obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
-"kvm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/spawner/random/maintenance/two,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor2/port)
 "kvw" = (
 /obj/machinery/igniter/incinerator_ordmix,
 /turf/open/floor/engine/vacuum,
@@ -39544,17 +40112,16 @@
 /turf/open/floor/carpet/green,
 /area/station/service/abandoned_gambling_den)
 "kxu" = (
-/obj/item/wheelchair{
-	pixel_y = -3
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/item/wheelchair,
-/obj/item/wheelchair{
-	pixel_y = 3
-	},
-/obj/structure/table/glass,
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
-/area/station/medical/storage)
+/area/station/medical/office)
 "kxA" = (
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /obj/machinery/camera/directional/south{
@@ -39612,22 +40179,15 @@
 	dir = 1
 	},
 /area/station/hallway/floor2/aft)
-"kxV" = (
-/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
-/turf/open/floor/pod/light,
-/area/station/maintenance/department/medical)
 "kxZ" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 10
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/station/medical/office)
 "kye" = (
 /obj/machinery/door/airlock/security{
 	name = "Perma"
@@ -39660,15 +40220,16 @@
 /turf/open/floor/engine/hull/reinforced,
 /area/space/nearstation)
 "kyq" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
-/area/station/medical/storage)
+/area/station/medical/medbay/aft)
 "kyw" = (
 /obj/machinery/gulag_teleporter,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -39697,12 +40258,6 @@
 "kyR" = (
 /turf/closed/wall,
 /area/station/hallway/floor1/fore)
-"kza" = (
-/obj/structure/railing/corner,
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
-/turf/open/floor/wood/parquet,
-/area/station/command/heads_quarters/cmo)
 "kzj" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -39738,17 +40293,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/genetics)
-"kzO" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/blue/arrow_cw{
-	dir = 1
-	},
-/obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "kzP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39777,6 +40321,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/third)
+"kAk" = (
+/obj/structure/cable,
+/obj/machinery/chem_master,
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/pharmacy)
 "kAm" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
@@ -39981,14 +40530,12 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/floor2/aft)
 "kCe" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
+/obj/structure/window/reinforced/spawner/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "kCi" = (
 /obj/effect/spawner/random/trash/bin,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -40086,8 +40633,12 @@
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen/abandoned)
 "kEl" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
@@ -40242,10 +40793,15 @@
 "kGh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/recharge_station,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/item/radio/intercom/directional/south,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/station/medical/medbay/aft)
 "kGq" = (
 /obj/effect/spawner/random/trash/garbage{
 	spawn_scatter_radius = 1
@@ -40532,6 +41088,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor2/port)
 "kJG" = (
@@ -40542,12 +41101,9 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/catwalk_floor,
-/area/station/maintenance/department/medical)
+/area/station/hallway/floor2/fore)
 "kJT" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Maintenance Bulkhead"
@@ -40764,6 +41320,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/pod,
 /area/station/maintenance/floor4/port/fore)
+"kMd" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/cryo)
 "kMh" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
 	dir = 10
@@ -40782,13 +41344,12 @@
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor2/starboard)
 "kMl" = (
-/obj/effect/turf_decal/trimline/blue/end{
-	dir = 4
-	},
-/obj/structure/sign/poster/official/random/directional/west,
-/obj/machinery/shower/directional/east,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/obj/effect/turf_decal/tile/blue/full,
+/obj/structure/table/glass,
+/obj/item/pai_card,
+/obj/item/reagent_containers/spray/cleaner,
+/turf/open/floor/iron/white/textured,
+/area/station/medical/treatment_center)
 "kMQ" = (
 /obj/structure/chair/sofa/bench{
 	dir = 4
@@ -40872,7 +41433,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue/fourcorners,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white/textured,
 /area/station/medical/break_room)
 "kOu" = (
 /obj/effect/turf_decal/siding/wood{
@@ -40987,21 +41548,23 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet,
 /area/station/security/detectives_office)
-"kQw" = (
-/obj/effect/turf_decal/trimline/blue/mid_joiner{
-	dir = 4
+"kQr" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
+/obj/machinery/button/door/directional/west{
+	id = "surg_a_privacy";
+	name = "Surgery Privacy Shutters";
+	req_access = list("medical")
 	},
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 4
+/obj/machinery/light_switch/directional/west{
+	pixel_y = -10;
+	pixel_x = -24
 	},
-/obj/effect/turf_decal/trimline/purple/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/purple/mid_joiner{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/hallway/floor2/fore)
+/turf/open/floor/iron/white,
+/area/station/medical/surgery/fore)
 "kQF" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 5
@@ -41036,7 +41599,6 @@
 /obj/effect/turf_decal/trimline/white/filled/corner{
 	dir = 1
 	},
-/obj/structure/reagent_dispensers/wall/peppertank/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
@@ -41318,20 +41880,6 @@
 /obj/item/storage/box/bodybags,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
-"kVd" = (
-/obj/structure/industrial_lift/public,
-/obj/machinery/lift_indicator/directional/east{
-	linked_elevator_id = "com_vator";
-	pixel_x = 38;
-	pixel_y = -7
-	},
-/obj/machinery/elevator_control_panel/directional/east{
-	linked_elevator_id = "com_vator";
-	pixel_x = 24;
-	preset_destination_names = list("4"="Service","5"="Command")
-	},
-/turf/open/floor/plating/elevatorshaft,
-/area/station/hallway/floor3/fore)
 "kVm" = (
 /obj/structure/railing{
 	dir = 10
@@ -41478,13 +42026,6 @@
 	},
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain)
-"kWz" = (
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/machinery/light/cold/directional/west,
-/obj/item/radio/intercom/directional/south,
-/obj/structure/closet/secure_closet/medical3,
-/turf/open/floor/iron/white,
-/area/station/medical/storage)
 "kWD" = (
 /obj/structure/fireaxecabinet/directional/north,
 /obj/machinery/keycard_auth/directional/north{
@@ -41527,6 +42068,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/start/psychologist,
 /obj/machinery/holopad,
+/obj/structure/sign/poster/official/random/directional/east,
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
 "kXj" = (
@@ -41550,6 +42092,17 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/station/hallway/floor3/aft)
+"kXE" = (
+/obj/structure/industrial_lift/public,
+/obj/effect/landmark/lift_id{
+	specific_lift_id = "com_vator"
+	},
+/obj/effect/abstract/elevator_music_zone{
+	linked_elevator_id = "com_vator";
+	range = 2
+	},
+/turf/open/openspace,
+/area/station/hallway/floor2/fore)
 "kXF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/bamboo/tatami/black,
@@ -41598,15 +42151,6 @@
 	},
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor3/starboard/aft)
-"kYB" = (
-/obj/machinery/cell_charger,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/structure/table/glass,
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/storage)
 "kYD" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/smooth_large,
@@ -41652,6 +42196,13 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/bar/atrium)
+"kZA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "kZG" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -41716,18 +42267,6 @@
 /obj/structure/cable,
 /turf/open/floor/carpet/green,
 /area/station/commons/dorms/apartment1)
-"laq" = (
-/obj/item/wrench/medical,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/obj/structure/table/glass,
-/obj/item/gun/syringe,
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/storage)
 "las" = (
 /obj/effect/turf_decal/tile/red/opposingcorners{
 	dir = 1
@@ -41744,6 +42283,15 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet/green,
 /area/station/commons/dorms/apartment1)
+"laG" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/item/radio/intercom/directional/east,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/light/cold/directional/east,
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "laJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41751,13 +42299,6 @@
 /obj/machinery/status_display/ai/directional/south,
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/floor3/fore)
-"laO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/storage)
 "laR" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
@@ -41912,6 +42453,16 @@
 	},
 /turf/open/floor/carpet/orange,
 /area/station/service/chapel/office)
+"lcP" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/medical/office)
 "lcU" = (
 /obj/effect/landmark/carpspawn,
 /turf/open/floor/engine/hull/reinforced,
@@ -41958,20 +42509,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
-"ldw" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/holopad,
-/turf/open/floor/iron/white/textured,
-/area/station/medical/medbay/central)
 "ldD" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Power Generation Experimentation"
@@ -41980,13 +42517,6 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/maintenance/floor1/port/aft)
-"ldG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/storage)
 "ldI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -42227,14 +42757,10 @@
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor4/starboard/aft)
 "lgH" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/station/medical/medbay/lobby)
 "lgI" = (
 /obj/machinery/light/small/red/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -42392,12 +42918,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den)
-"liq" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "liL" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
@@ -42522,11 +43042,6 @@
 	dir = 1
 	},
 /area/station/medical/chemistry)
-"lkL" = (
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/machinery/light/cold/directional/east,
-/turf/open/floor/iron/white,
-/area/station/medical/storage)
 "lkP" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -42795,11 +43310,12 @@
 	},
 /area/station/security/office)
 "lnq" = (
-/obj/effect/turf_decal/siding/white,
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
-/obj/machinery/computer/records/medical,
-/turf/open/floor/iron/dark,
+/obj/structure/table/reinforced/rglass,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/item/stack/medical/gauze,
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/medbay/lobby)
 "lnr" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
@@ -42834,6 +43350,14 @@
 /obj/structure/flora/bush/sparsegrass/style_random,
 /turf/open/floor/grass,
 /area/station/service/bar/atrium)
+"lnQ" = (
+/obj/structure/mirror/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/machinery/camera/autoname/directional/south,
+/turf/open/floor/iron/white/herringbone,
+/area/station/medical/patients_rooms)
 "lnU" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/effect/spawner/random/structure/tank_holder,
@@ -42933,10 +43457,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "lpb" = (
-/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
 /obj/machinery/light/cold/directional/north,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/station/medical/medbay/lobby)
 "lpc" = (
 /obj/structure/railing{
 	dir = 10
@@ -43049,25 +43575,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/fore)
 "lqz" = (
-/obj/item/storage/medkit/toxin{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/storage/medkit/toxin,
-/obj/item/storage/medkit/toxin{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/closet/crate/freezer/surplus_limbs,
 /obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/item/storage/medkit/regular,
-/obj/machinery/door/window/left/directional/north{
-	name = "First Aid Supplies";
-	req_access = list("medical")
-	},
+/obj/structure/sign/poster/official/random/directional/west,
 /turf/open/floor/iron/white,
-/area/station/medical/storage)
+/area/station/medical/surgery/fore)
 "lqB" = (
 /obj/effect/spawner/random/structure/table_or_rack,
 /obj/effect/spawner/random/maintenance/two,
@@ -43103,26 +43615,6 @@
 /obj/structure/sink/directional/west,
 /turf/open/floor/iron/freezer,
 /area/station/command/heads_quarters/ce)
-"lqJ" = (
-/obj/item/storage/medkit/fire{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/storage/medkit/fire,
-/obj/item/storage/medkit/fire{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/item/storage/medkit/regular,
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/machinery/door/window/right/directional/north{
-	name = "First Aid Supplies";
-	req_access = list("medical")
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/storage)
 "lqK" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 8
@@ -43168,10 +43660,25 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor4/fore)
 "lrX" = (
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/structure/closet/secure_closet/medical3,
-/turf/open/floor/iron/white,
-/area/station/medical/storage)
+/obj/item/storage/backpack/duffelbag/med/surgery{
+	pixel_y = 13
+	},
+/obj/item/reagent_containers/medigel/sterilizine{
+	pixel_x = 1
+	},
+/obj/item/reagent_containers/syringe{
+	pixel_x = -7
+	},
+/obj/item/stack/medical/bone_gel{
+	pixel_x = 10
+	},
+/obj/effect/turf_decal/box/white,
+/obj/structure/table/reinforced/rglass,
+/obj/effect/turf_decal/siding/white{
+	dir = 9
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/surgery/fore)
 "lsm" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -43247,19 +43754,6 @@
 	name = "lab floor"
 	},
 /area/station/science/genetics)
-"ltj" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/arrow_cw{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "ltn" = (
 /obj/item/storage/toolbox/mechanical/old,
 /turf/open/floor/plating,
@@ -43417,7 +43911,14 @@
 /area/station/commons/vacant_room/office)
 "lvs" = (
 /obj/machinery/door/firedoor,
-/turf/open/floor/iron/white,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/abandoned)
 "lvy" = (
 /obj/machinery/light/directional/west,
@@ -43608,7 +44109,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/sign/departments/medbay/alt/directional/south,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/floor2/aft)
 "lxZ" = (
@@ -43689,14 +44192,6 @@
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor2/port/fore)
-"lzp" = (
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/storage)
 "lzq" = (
 /obj/structure/railing{
 	dir = 6
@@ -43752,13 +44247,17 @@
 /turf/open/floor/iron/checker,
 /area/station/cargo/miningdock)
 "lAE" = (
-/obj/machinery/iv_drip,
-/obj/structure/mirror/directional/south,
-/obj/structure/sign/poster/official/cleanliness/directional/east,
-/obj/machinery/camera/autoname/directional/east,
+/obj/machinery/requests_console/directional/south{
+	department = "Medbay";
+	name = "Medbay Requests Console"
+	},
+/obj/effect/mapping_helpers/requests_console/supplies,
+/obj/effect/mapping_helpers/requests_console/assistance,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/structure/closet/secure_closet/medical3,
 /obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/iron/dark,
-/area/station/medical/surgery/fore)
+/turf/open/floor/iron/white/textured,
+/area/station/medical/storage)
 "lAH" = (
 /obj/structure/flora/bush/sparsegrass/style_random,
 /obj/item/stack/rods{
@@ -43969,6 +44468,13 @@
 	},
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor4/starboard/aft)
+"lDn" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor,
+/area/station/maintenance/floor3/port/aft)
 "lDs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -44017,9 +44523,12 @@
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor3/port/fore)
 "lDM" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall,
-/area/station/medical/storage)
+/obj/structure/closet/crate/freezer/blood,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/light/cold/directional/west,
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron/white,
+/area/station/medical/surgery/fore)
 "lDW" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 4
@@ -44049,6 +44558,13 @@
 /obj/machinery/duct,
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/captain/private)
+"lEm" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "lEo" = (
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/rd)
@@ -44115,6 +44631,15 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
+"lEV" = (
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/hallway/floor2/fore)
 "lFa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -44235,14 +44760,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/floor2/aft)
 "lGA" = (
-/obj/structure/railing/corner{
-	dir = 4
+/obj/machinery/door/airlock/hatch{
+	name = "Maintenance Access"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/any/medical/psychology,
 /turf/open/floor/catwalk_floor,
-/area/station/maintenance/department/medical)
+/area/station/hallway/floor2/fore)
 "lGH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -44643,12 +45166,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/floor2/port/aft)
 "lLP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
-/obj/structure/sign/poster/official/random/directional/east,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/station/medical/medbay/lobby)
 "lMt" = (
 /obj/structure/cable,
 /turf/open/floor/iron/white/smooth_corner,
@@ -44975,20 +45498,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/checker,
 /area/station/service/bar)
-"lPL" = (
-/obj/structure/table/reinforced/rglass,
-/obj/item/storage/pill_bottle/mannitol,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/item/reagent_containers/cup/beaker/cryoxadone{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/cup/beaker/cryoxadone{
-	pixel_x = -6;
-	pixel_y = 10
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/medical/cryo)
 "lPR" = (
 /obj/structure/railing{
 	dir = 8
@@ -45153,6 +45662,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor3/port/aft)
 "lRi" = (
@@ -45406,6 +45916,14 @@
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor,
 /area/station/hallway/floor3/fore)
+"lVd" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "lVf" = (
 /obj/structure/disposalpipe/junction/flip,
 /turf/open/floor/iron,
@@ -45526,6 +46044,17 @@
 /obj/effect/mapping_helpers/requests_console/ore_update,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
+"lXi" = (
+/obj/machinery/door/airlock/medical{
+	name = "Recovery Room"
+	},
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/patients_rooms)
 "lXj" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -45573,12 +46102,9 @@
 "lXz" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light/cold/directional/south,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/machinery/light/cold/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "lXK" = (
@@ -45605,10 +46131,6 @@
 /obj/structure/sign/poster/random/directional/west,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor3/port/aft)
-"lXO" = (
-/obj/machinery/vending/drugs,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "lXT" = (
 /obj/structure/railing,
 /obj/effect/decal/cleanable/dirt,
@@ -45670,10 +46192,12 @@
 /turf/open/floor/carpet/red,
 /area/station/service/library/lounge)
 "lYl" = (
-/obj/structure/lattice/catwalk,
-/obj/effect/spawner/random/maintenance,
-/turf/open/openspace,
-/area/station/maintenance/floor2/port)
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/white/herringbone,
+/area/station/medical/patients_rooms)
 "lYr" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
@@ -45931,7 +46455,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/abandoned)
 "mbS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
@@ -46013,6 +46543,15 @@
 	},
 /turf/open/floor/wood/tile,
 /area/station/service/library/lounge)
+"mcC" = (
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/light/cold/directional/east,
+/turf/open/floor/iron/white/textured,
+/area/station/medical/storage)
 "mcD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -46020,6 +46559,12 @@
 /obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron/white/textured_large,
 /area/station/service/chapel/office)
+"mcH" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/station/hallway/floor2/aft)
 "mcI" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -46204,7 +46749,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/dark,
 /area/station/medical/psychology)
 "meK" = (
 /obj/structure/closet/emcloset,
@@ -46245,12 +46790,6 @@
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/service/library/lounge)
-"mfy" = (
-/obj/effect/turf_decal/tile/blue/full,
-/obj/structure/table/glass,
-/obj/item/pai_card,
-/turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
 "mfE" = (
 /obj/effect/turf_decal/tile/green/opposingcorners,
 /obj/structure/table/reinforced,
@@ -46309,12 +46848,6 @@
 /obj/effect/spawner/random/maintenance/three,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port)
-"mgh" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/structure/closet/l3closet,
-/obj/structure/sign/poster/official/random/directional/north,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "mgl" = (
 /obj/structure/sign/directions/evac/directional/west,
 /obj/structure/sign/directions/supply/directional/west{
@@ -46359,12 +46892,6 @@
 /obj/structure/sign/warning/radiation/rad_area,
 /turf/closed/wall,
 /area/station/maintenance/floor1/port/aft)
-"mgF" = (
-/obj/effect/turf_decal/trimline/blue/arrow_cw{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "mgG" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/trash/cigbutt,
@@ -46705,6 +47232,13 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/wood,
 /area/station/hallway/floor3/fore)
+"mmc" = (
+/obj/machinery/smartfridge/organ,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "mme" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -46984,6 +47518,17 @@
 /obj/machinery/bookbinder,
 /turf/open/floor/carpet/red,
 /area/station/service/library)
+"mpu" = (
+/obj/structure/chair/sofa/corp/left{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/effect/landmark/start/paramedic,
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/paramedic)
 "mpy" = (
 /obj/machinery/newscaster/directional/west,
 /obj/effect/decal/cleanable/dirt,
@@ -47267,11 +47812,12 @@
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor3/starboard)
 "msw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
+/obj/machinery/atmospherics/components/unary/cryo_cell{
+	dir = 8
+	},
+/obj/structure/sign/poster/official/random/directional/east,
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/cryo)
 "msL" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/pod/light,
@@ -47306,7 +47852,7 @@
 /area/station/service/chapel)
 "mtg" = (
 /obj/structure/railing/corner,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/dark,
 /area/station/medical/psychology)
 "mtj" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -47418,16 +47964,6 @@
 	},
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor2/starboard/fore)
-"muN" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "muO" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark/side{
@@ -47486,13 +48022,11 @@
 /area/station/hallway/floor4/fore)
 "mvJ" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 9
 	},
-/obj/machinery/fax{
-	fax_name = "Medical";
-	name = "Medical Fax Machine"
-	},
-/obj/structure/table/wood,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/wood/parquet,
 /area/station/medical/break_room)
 "mvK" = (
@@ -47667,8 +48201,9 @@
 /turf/open/floor/iron/white/textured_large,
 /area/station/service/chapel/office)
 "myz" = (
+/obj/structure/lattice,
 /turf/open/openspace,
-/area/station/maintenance/department/medical)
+/area/station/hallway/floor2/fore)
 "myF" = (
 /obj/machinery/smartfridge/chemistry/preloaded,
 /obj/machinery/door/firedoor,
@@ -47803,10 +48338,13 @@
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/captain/private)
 "mAb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/wood/parquet,
-/area/station/command/heads_quarters/cmo)
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/structure/chair/plastic,
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "mAr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -47906,6 +48444,12 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/white,
 /area/station/science/lower)
+"mCj" = (
+/obj/structure/sign/poster/official/random/directional/west,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/smartfridge/organ,
+/turf/open/floor/iron/white/textured,
+/area/station/medical/office)
 "mCo" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -48083,6 +48627,15 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor1/port)
+"mEd" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/obj/machinery/firealarm/directional/south,
+/obj/machinery/light/cold/directional/south,
+/obj/machinery/camera/autoname/directional/east,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "mEf" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional,
 /turf/open/floor/plating,
@@ -48253,6 +48806,17 @@
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron/white,
 /area/station/science/lower)
+"mGg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/medical/office)
 "mGp" = (
 /obj/effect/spawner/random/trash/garbage{
 	spawn_scatter_radius = 1
@@ -48311,13 +48875,13 @@
 	},
 /area/station/security/lockers)
 "mGW" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/item/radio/intercom/directional/east,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
+	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
+/obj/machinery/duct,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "mGY" = (
 /obj/machinery/newscaster/directional/north,
 /obj/machinery/disposal/bin,
@@ -48397,6 +48961,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/science/circuits)
+"mHU" = (
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/machinery/airalarm/directional/south,
+/obj/structure/table/reinforced,
+/obj/item/gun/syringe,
+/turf/open/floor/iron/white,
+/area/station/medical/pharmacy)
 "mHV" = (
 /obj/structure/closet/secure_closet/security/sec,
 /obj/structure/sign/poster/official/random/directional/north,
@@ -48835,6 +49406,12 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron/smooth,
 /area/station/cargo/warehouse)
+"mMN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/command/heads_quarters/cmo)
 "mMO" = (
 /obj/effect/landmark/blobstart,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -48967,7 +49544,7 @@
 "mOT" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/poddoor/preopen{
+/obj/machinery/door/poddoor{
 	elevator_linked_id = "com_vator";
 	elevator_mode = 1
 	},
@@ -49552,17 +50129,12 @@
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "mWi" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
+/obj/structure/railing{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/arrow_cw{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/obj/machinery/duct,
+/turf/open/floor/wood/parquet,
+/area/station/command/heads_quarters/cmo)
 "mWn" = (
 /obj/machinery/door/airlock/vault{
 	name = "Vault"
@@ -49616,17 +50188,6 @@
 /obj/structure/sign/poster/official/random/directional/west,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port)
-"mWW" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/blue/arrow_cw{
-	dir = 1
-	},
-/obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "mXg" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
@@ -49654,6 +50215,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
+"mXq" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/medical/office)
 "mXC" = (
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/pod/dark,
@@ -49747,7 +50317,13 @@
 /turf/open/floor/engine/hull/reinforced,
 /area/space/nearstation)
 "mYN" = (
-/turf/closed/wall,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/cmo)
 "mYV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -49784,6 +50360,19 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
+"mZx" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/medbay/central)
 "mZy" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -49842,6 +50431,15 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/textured_large,
 /area/station/engineering/lobby)
+"naf" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/storage)
 "nag" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/structure/table/reinforced,
@@ -50155,10 +50753,14 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor3/aft)
 "neu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/co2{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/duct,
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/cryo)
 "new" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron,
@@ -50306,11 +50908,13 @@
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor4/starboard/fore)
 "ngg" = (
-/obj/machinery/airalarm/directional/south,
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/structure/closet/secure_closet/medical3,
-/turf/open/floor/iron/white,
-/area/station/medical/storage)
+/obj/machinery/light/cold/directional/east,
+/obj/machinery/newscaster/directional/east,
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/surgery/fore)
 "ngi" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -50484,26 +51088,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/floor3/aft)
 "nhI" = (
-/obj/item/storage/medkit/brute{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/storage/medkit/brute,
-/obj/item/storage/medkit/brute{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/structure/table/reinforced,
-/obj/item/storage/medkit/regular,
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/window/right/directional/south{
-	name = "First Aid Supplies";
-	req_access = list("medical")
-	},
-/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/iron/white,
-/area/station/medical/storage)
+/area/station/medical/office)
 "nhJ" = (
 /obj/machinery/chem_master,
 /obj/structure/noticeboard/directional/west,
@@ -50688,6 +51275,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/starboard/fore)
+"njp" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "njq" = (
 /obj/effect/spawner/structure/window/hollow/end{
 	dir = 8
@@ -50749,12 +51345,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
-"njW" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/wood/parquet,
-/area/station/medical/break_room)
 "nkh" = (
 /obj/machinery/power/tracker,
 /obj/structure/cable,
@@ -50992,6 +51582,10 @@
 "nmV" = (
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
+"nmZ" = (
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/iron/white,
+/area/station/command/heads_quarters/cmo)
 "nnb" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/hidden/layer1,
 /obj/structure/disposalpipe/segment{
@@ -51011,6 +51605,7 @@
 /obj/effect/turf_decal/stripes/red/line,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/door/firedoor/border_only,
+/obj/structure/railing/corner,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor3/port/aft)
 "nnf" = (
@@ -51046,13 +51641,6 @@
 	},
 /turf/open/floor/iron/textured_large,
 /area/station/engineering/atmos)
-"nnw" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
 "nnJ" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/iron/dark/smooth_large,
@@ -51185,11 +51773,22 @@
 /turf/open/floor/iron/dark/side,
 /area/station/engineering/atmos)
 "noN" = (
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/storage)
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/medbay/aft)
 "noO" = (
 /obj/machinery/porta_turret/ai{
 	dir = 4
@@ -51208,32 +51807,20 @@
 	},
 /area/station/commons/fitness)
 "npc" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/blood/drip,
+/obj/structure/sink/directional/west,
+/obj/structure/mirror/directional/east,
+/turf/open/floor/iron/white/textured,
+/area/station/medical/storage)
 "nph" = (
 /obj/structure/chair/sofa/bench/right{
 	dir = 1
 	},
 /turf/open/floor/iron/textured_large,
 /area/station/hallway/secondary/exit/departure_lounge)
-"npm" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 1
-	},
-/obj/structure/sign/departments/chemistry/pharmacy{
-	pixel_x = -32
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "npD" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -51273,6 +51860,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/textured_large,
 /area/station/hallway/secondary/exit/departure_lounge)
+"npY" = (
+/obj/structure/chair/sofa/corp{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/effect/landmark/start/paramedic,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/paramedic)
 "npZ" = (
 /obj/effect/turf_decal/trimline/green/warning,
 /turf/open/floor/pod/light,
@@ -51407,6 +52005,14 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/service)
+"nrE" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/cold/directional/west,
+/obj/structure/sign/poster/official/random/directional/west,
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "nrM" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -51510,24 +52116,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/textured_half,
 /area/station/cargo/office)
-"nsE" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/left/directional/north{
-	name = "Pharmacy Desk"
+"nsD" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 8
 	},
-/obj/machinery/door/window/left/directional/north{
-	dir = 2;
-	name = "Pharmacy Desk";
-	req_access = list("pharmacy")
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 1;
-	id = "chem-lockdown";
-	name = "Chemistry Shutters"
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/pharmacy)
+/obj/structure/bed/roller,
+/obj/machinery/iv_drip,
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/office)
 "nsL" = (
 /obj/effect/turf_decal/trimline/purple/corner,
 /obj/effect/turf_decal/trimline/purple/filled/corner{
@@ -51592,12 +52188,6 @@
 /obj/structure/cable/layer3,
 /turf/open/floor/iron/dark,
 /area/space/nearstation)
-"ntH" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/station/medical/morgue)
 "ntO" = (
 /obj/effect/turf_decal/trimline/purple/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -51649,7 +52239,7 @@
 /obj/machinery/door/window/brigdoor/left/directional/south{
 	name = "Virology Desk"
 	},
-/obj/machinery/door/poddoor/shutters{
+/obj/machinery/door/poddoor/shutters/preopen{
 	id = "viro-inner";
 	name = "Virology Inner Shutters"
 	},
@@ -51673,9 +52263,9 @@
 /turf/open/floor/catwalk_floor,
 /area/station/hallway/floor4/aft)
 "nuG" = (
-/obj/structure/bookcase/random/reference,
-/turf/open/floor/carpet,
-/area/station/medical/psychology)
+/obj/structure/industrial_lift/public,
+/turf/open/floor/plating/elevatorshaft,
+/area/station/hallway/floor2/fore)
 "nuM" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
 	dir = 5
@@ -51965,11 +52555,6 @@
 	},
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor3/starboard/aft)
-"nyx" = (
-/obj/machinery/smartfridge/organ,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white,
-/area/station/medical/storage)
 "nyE" = (
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/turret_protected/ai_upload_foyer)
@@ -52066,8 +52651,12 @@
 	},
 /area/station/security/brig)
 "nzz" = (
-/turf/open/floor/iron/dark/textured,
-/area/station/medical/surgery/fore)
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/storage)
 "nzK" = (
 /obj/structure/flora/bush/sparsegrass/style_random,
 /obj/item/stack/rods{
@@ -52126,6 +52715,13 @@
 /obj/structure/flora/bush/lavendergrass/style_random,
 /turf/open/floor/grass,
 /area/station/security/courtroom)
+"nAD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/aft)
 "nAE" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
@@ -52179,18 +52775,6 @@
 /obj/structure/frame/computer,
 /turf/open/floor/iron/smooth,
 /area/station/construction)
-"nBt" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/junction/flip{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "nBw" = (
 /obj/effect/turf_decal/trimline/brown/line{
 	dir = 4
@@ -52789,6 +53373,15 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/maintenance/floor2/starboard/aft)
+"nIF" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/paramedic)
 "nIL" = (
 /obj/effect/turf_decal/siding/purple,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -52986,6 +53579,12 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/checker,
 /area/station/service/bar)
+"nLq" = (
+/obj/effect/turf_decal/tile/blue/full,
+/obj/structure/table/glass,
+/obj/item/storage/box/hug/medical,
+/turf/open/floor/iron/white/textured,
+/area/station/medical/treatment_center)
 "nLs" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -53015,16 +53614,6 @@
 /obj/structure/sign/poster/random/directional/north,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology/hallway)
-"nLI" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/sign/poster/official/random/directional/north,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "nLL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -53055,11 +53644,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/theater)
-"nMm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/medical/exam_room)
 "nMn" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/emcloset,
@@ -53082,13 +53666,17 @@
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/starboard/fore)
 "nMO" = (
-/obj/machinery/light/cold/directional/south,
-/obj/structure/sign/poster/official/random/directional/south,
-/obj/effect/turf_decal/trimline/blue/arrow_cw{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/station/command/heads_quarters/cmo)
 "nMU" = (
 /obj/structure/disposalpipe/trunk/multiz/down,
 /turf/open/openspace,
@@ -53254,14 +53842,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
-"nPo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 9
-	},
-/obj/effect/spawner/random/engineering/atmospherics_portable,
-/turf/open/floor/pod/light,
-/area/station/maintenance/floor2/port)
 "nPp" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/yellow,
@@ -53324,6 +53904,19 @@
 "nPQ" = (
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
+"nPR" = (
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/camera/autoname/directional/west,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/station/command/heads_quarters/cmo)
 "nPS" = (
 /obj/structure/mirror/directional/south,
 /obj/machinery/duct,
@@ -53506,8 +54099,12 @@
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor1/port/fore)
 "nRQ" = (
-/obj/machinery/chem_master,
-/obj/structure/noticeboard/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/landmark/start/chemist,
+/obj/structure/chair/office{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/pharmacy)
 "nRU" = (
@@ -53608,9 +54205,17 @@
 /turf/open/floor/carpet,
 /area/station/service/lawoffice)
 "nTx" = (
-/obj/structure/sink/directional/west,
-/turf/open/floor/iron/dark,
-/area/station/medical/surgery/fore)
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/storage)
 "nTB" = (
 /obj/structure/fluff/oldturret,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
@@ -53671,9 +54276,14 @@
 /turf/open/floor/carpet/purple,
 /area/station/commons/dorms/apartment1)
 "nUC" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/medical/exam_room)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/holopad,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/command/heads_quarters/cmo)
 "nUI" = (
 /obj/structure/industrial_lift/public,
 /obj/machinery/lift_indicator/directional/east{
@@ -53896,6 +54506,12 @@
 	dir = 1
 	},
 /area/station/command/gateway)
+"nWT" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/pharmacy)
 "nWW" = (
 /turf/closed/wall,
 /area/station/hallway/floor4/aft)
@@ -54062,13 +54678,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
-"nYX" = (
-/obj/effect/turf_decal/trimline/purple/warning{
-	dir = 10
-	},
-/obj/structure/reagent_dispensers/plumbed,
-/turf/open/floor/pod/light,
-/area/station/maintenance/floor2/port)
 "nYZ" = (
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -54119,6 +54728,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
+"nZo" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/medical/office)
 "nZq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/soap,
@@ -54175,6 +54792,15 @@
 "oaE" = (
 /turf/open/floor/engine/n2,
 /area/station/engineering/atmos)
+"oaP" = (
+/obj/effect/turf_decal/tile/blue/full,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/white/textured,
+/area/station/medical/treatment_center)
 "oaS" = (
 /obj/item/toy/crayon/spraycan,
 /obj/structure/table,
@@ -54199,6 +54825,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/auxlab)
+"obl" = (
+/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
+/obj/machinery/door/window/brigdoor/right/directional/east{
+	name = "Anesthetic Storage";
+	req_access = list("medical")
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/storage)
 "obs" = (
 /obj/item/stack/tile/iron/white,
 /turf/open/floor/plating,
@@ -54255,6 +54892,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/security/brig)
+"ocf" = (
+/obj/effect/spawner/structure/window/hollow/directional,
+/turf/open/floor/pod/dark,
+/area/station/maintenance/floor3/port)
 "ocl" = (
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/engine,
@@ -54337,8 +54978,8 @@
 /turf/open/floor/carpet/red,
 /area/station/service/theater)
 "ocX" = (
-/obj/effect/spawner/random/contraband/landmine,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/girder,
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor2/port)
 "ode" = (
@@ -54483,21 +55124,11 @@
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/wood,
 /area/station/commons/dorms/apartment2)
-"ofI" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white,
-/area/station/command/heads_quarters/cmo)
 "ofY" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/turf/open/floor/iron/dark/textured,
-/area/station/medical/cryo)
+/obj/machinery/vending/medical,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/white/textured,
+/area/station/medical/medbay/central)
 "ogc" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -54525,7 +55156,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/iron/white,
 /area/station/medical/abandoned)
 "ogp" = (
 /obj/effect/spawner/random/trash/graffiti,
@@ -54587,12 +55218,13 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "ohj" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/medical/treatment_center)
 "ohm" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/carpet,
@@ -54634,12 +55266,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
-"ohL" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/structure/cable,
-/obj/machinery/vending/wardrobe/chem_wardrobe,
-/turf/open/floor/iron/white,
-/area/station/medical/pharmacy)
 "ohO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark/side{
@@ -54885,11 +55511,12 @@
 	dir = 8
 	},
 /area/station/medical/chemistry)
-"okN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/holopad,
+"okQ" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
-/area/station/command/heads_quarters/cmo)
+/area/station/medical/office)
 "okT" = (
 /obj/structure/railing{
 	dir = 1
@@ -55394,10 +56021,12 @@
 /turf/open/floor/iron/textured_large,
 /area/station/cargo/sorting)
 "ora" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
 	},
-/obj/machinery/light/cold/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "orf" = (
@@ -55468,6 +56097,14 @@
 /obj/effect/mapping_helpers/mail_sorting/engineering/general,
 /turf/open/floor/iron,
 /area/station/hallway/floor1/aft)
+"osy" = (
+/obj/machinery/iv_drip,
+/obj/structure/mirror/directional/south,
+/obj/machinery/camera/autoname/directional/east,
+/obj/effect/decal/cleanable/blood/old,
+/obj/structure/sign/poster/official/cleanliness/directional/east,
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/surgery/fore)
 "osI" = (
 /obj/machinery/light/red/dim/directional/east,
 /turf/open/floor/pod/dark,
@@ -55492,6 +56129,9 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/science/circuits)
+"otp" = (
+/turf/closed/wall/r_wall,
+/area/station/hallway/floor2/aft)
 "otr" = (
 /obj/structure/mirror/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -55630,14 +56270,14 @@
 /turf/open/floor/iron/textured_large,
 /area/station/cargo/sorting)
 "ovI" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/item/radio/intercom/directional/west,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/filingcabinet/chestdrawer,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
+	dir = 10
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "ovK" = (
 /turf/open/floor/carpet/neon/simple/white,
 /area/station/commons/dorms/room3)
@@ -55811,17 +56451,29 @@
 /area/station/service/bar/atrium)
 "oys" = (
 /obj/structure/sign/poster/official/random/directional/west,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/dark,
 /area/station/medical/psychology)
 "oyt" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
+/obj/item/storage/medkit/o2{
+	pixel_x = -3;
+	pixel_y = -3
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+/obj/item/storage/medkit/o2,
+/obj/item/storage/medkit/o2{
+	pixel_x = 3;
+	pixel_y = 3
 	},
-/turf/open/floor/iron/white,
-/area/station/command/heads_quarters/cmo)
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/item/storage/medkit/regular,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/window/left/directional/south{
+	name = "First Aid Supplies";
+	req_access = list("medical")
+	},
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/white/textured,
+/area/station/medical/storage)
 "oyF" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/door/firedoor/border_only,
@@ -55860,10 +56512,13 @@
 /turf/open/floor/iron/white,
 /area/station/hallway/floor2/aft)
 "oyT" = (
-/obj/item/radio/intercom/directional/south,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/floor2/aft)
 "oyZ" = (
@@ -55882,11 +56537,14 @@
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor2/port/aft)
 "ozj" = (
-/obj/machinery/light/cold/directional/north,
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal/bin,
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
+/obj/machinery/newscaster/directional/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/structure/table/reinforced/rglass,
+/obj/item/storage/box/bodybags,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "ozn" = (
 /obj/structure/railing{
 	dir = 9
@@ -56022,6 +56680,7 @@
 /area/space/nearstation)
 "oAU" = (
 /obj/machinery/light/warm/directional/west,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/carpet/royalblue,
 /area/station/medical/break_room)
 "oAZ" = (
@@ -56125,12 +56784,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor2/fore)
-"oCl" = (
-/obj/machinery/newscaster/directional/north{
-	name = "PropagandaNet Uplink"
-	},
-/turf/open/floor/carpet,
-/area/station/medical/psychology)
 "oCw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -56181,6 +56834,17 @@
 /obj/structure/stairs/west,
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor3/starboard)
+"oDr" = (
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/structure/table/glass,
+/obj/item/reagent_containers/cup/bottle/epinephrine,
+/obj/item/reagent_containers/cup/bottle/multiver{
+	pixel_x = 6
+	},
+/obj/item/reagent_containers/syringe,
+/obj/structure/sign/poster/official/random/directional/west,
+/turf/open/floor/iron/white/textured,
+/area/station/medical/treatment_center)
 "oDI" = (
 /obj/structure/table/reinforced,
 /obj/item/restraints/handcuffs,
@@ -56408,6 +57072,15 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/station/hallway/floor3/aft)
+"oGw" = (
+/obj/structure/closet/crate/freezer/blood{
+	anchored = 1
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 10
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/office)
 "oGD" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -56671,6 +57344,9 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/storage/tech)
+"oKx" = (
+/turf/closed/wall/r_wall,
+/area/station/medical/storage)
 "oKD" = (
 /obj/machinery/photocopier,
 /obj/machinery/requests_console/directional/west{
@@ -56736,6 +57412,11 @@
 /obj/structure/beebox,
 /turf/open/floor/grass,
 /area/station/service/hydroponics)
+"oLH" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/white,
+/area/station/medical/abandoned)
 "oLL" = (
 /obj/structure/toilet{
 	dir = 4
@@ -56750,6 +57431,15 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/textured_large,
 /area/station/cargo/storage)
+"oLV" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/duct,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/aft)
 "oMd" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 4
@@ -56786,13 +57476,15 @@
 /turf/open/floor/grass,
 /area/station/medical/virology)
 "oMF" = (
-/obj/item/pen,
-/obj/item/folder/white,
-/obj/item/hand_labeler,
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/structure/table/glass,
-/turf/open/floor/iron/white/textured,
-/area/station/medical/medbay/central)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/duct,
+/turf/open/floor/wood/parquet,
+/area/station/command/heads_quarters/cmo)
 "oMJ" = (
 /obj/structure/railing{
 	dir = 1
@@ -56893,14 +57585,6 @@
 	dir = 10
 	},
 /area/station/hallway/floor1/fore)
-"oNR" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/structure/sign/departments/exam_room/directional/east,
-/obj/effect/turf_decal/trimline/blue/arrow_cw{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "oNV" = (
 /obj/machinery/shower/directional/west,
 /obj/effect/landmark/start/hangover,
@@ -57008,10 +57692,6 @@
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/psychology)
-"oPD" = (
-/obj/structure/closet/firecloset,
-/turf/open/floor/iron/dark,
-/area/station/hallway/floor2/fore)
 "oPH" = (
 /obj/structure/table,
 /obj/item/folder/yellow,
@@ -57098,19 +57778,6 @@
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/wood/tile,
 /area/station/commons/fitness/recreation)
-"oQF" = (
-/obj/structure/bed/double{
-	dir = 4
-	},
-/obj/item/bedsheet/cmo/double{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/effect/landmark/start/chief_medical_officer,
-/turf/open/floor/carpet/royalblue,
-/area/station/command/heads_quarters/cmo)
 "oQL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -57285,11 +57952,17 @@
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "oSC" = (
-/obj/machinery/airalarm/directional/east,
-/obj/machinery/light/cold/directional/east,
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "med_doors";
+	name = "Medbay"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/effect/mapping_helpers/airlock/access/any/medical/general,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/turf/open/floor/iron/white/textured,
+/area/station/medical/medbay/lobby)
 "oSD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -57446,13 +58119,15 @@
 /turf/open/floor/mineral/silver,
 /area/station/service/chapel/funeral)
 "oUy" = (
-/obj/machinery/light/directional/south,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/sign/departments/chemistry/pharmacy/directional/south,
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes/white/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/white/corner{
+	dir = 8
+	},
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/floor2/aft)
 "oUH" = (
@@ -57476,25 +58151,38 @@
 	},
 /area/station/science/genetics)
 "oUS" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/blue/arrow_cw{
+/obj/structure/railing{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
-"oUZ" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/duct,
+/turf/open/floor/wood/parquet,
+/area/station/command/heads_quarters/cmo)
+"oUX" = (
+/obj/machinery/computer/operating{
+	dir = 1
+	},
+/obj/machinery/vending/wallmed/directional/south,
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/surgery/aft)
+"oUZ" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/obj/structure/table/glass,
+/obj/item/reagent_containers/hypospray/medipen,
+/obj/item/reagent_containers/hypospray/medipen,
+/obj/item/reagent_containers/hypospray/medipen,
+/obj/item/reagent_containers/hypospray/medipen,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/station/medical/medbay/lobby)
 "oVf" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark/side{
@@ -57620,14 +58308,6 @@
 /obj/structure/railing/corner,
 /turf/open/space/openspace,
 /area/space/nearstation)
-"oXg" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/blue/arrow_cw{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "oXQ" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/structure/cable,
@@ -57773,14 +58453,6 @@
 /obj/structure/sign/poster/official/random/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/second)
-"oZA" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
 "oZE" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Maintenance Hatch"
@@ -57930,10 +58602,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/floor4/starboard)
 "pcB" = (
-/obj/structure/closet/secure_closet/medical2,
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/turf/open/floor/iron/white,
-/area/station/medical/surgery/aft)
+/turf/closed/wall,
+/area/station/medical/office)
 "pcC" = (
 /turf/open/openspace,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
@@ -58201,6 +58871,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/floor2/aft)
 "pie" = (
@@ -58230,12 +58901,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
-"pil" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
 "piq" = (
 /obj/machinery/holopad,
 /obj/effect/landmark/start/mime,
@@ -58308,6 +58973,12 @@
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
+"pjA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/iron/white/herringbone,
+/area/station/medical/patients_rooms)
 "pjB" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/chair{
@@ -58449,16 +59120,19 @@
 /obj/item/clothing/head/costume/allies,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor4/port)
-"pmk" = (
-/obj/structure/chair/office{
-	dir = 1
-	},
+"pmj" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/iron/white,
-/area/station/command/heads_quarters/cmo)
+/area/station/medical/storage)
+"pmk" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/medical/storage)
 "pmn" = (
 /obj/effect/turf_decal/trimline/green/warning{
 	dir = 1
@@ -58722,6 +59396,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port/fore)
+"pps" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/medical/office)
+"ppy" = (
+/turf/closed/wall/r_wall,
+/area/station/medical/medbay/lobby)
 "ppN" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Tech Storage"
@@ -58786,9 +59470,17 @@
 	},
 /area/station/hallway/floor2/aft)
 "pqm" = (
-/obj/structure/lattice,
-/turf/open/openspace,
-/area/station/maintenance/floor2/port)
+/obj/structure/sink/directional/west,
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/surgery/aft)
+"pqq" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/vending/clothing,
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/iron/white/herringbone,
+/area/station/medical/patients_rooms)
 "pqy" = (
 /obj/machinery/camera{
 	c_tag = "Power Storage";
@@ -59042,6 +59734,11 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
+"pud" = (
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/structure/sign/poster/official/moth_meth/directional/south,
+/turf/open/floor/iron/white,
+/area/station/medical/pharmacy)
 "pug" = (
 /obj/structure/table/wood,
 /obj/item/storage/photo_album/chapel,
@@ -59184,12 +59881,11 @@
 /turf/open/floor/iron/dark/corner,
 /area/station/commons/storage/primary)
 "pvM" = (
-/obj/machinery/computer/operating{
-	dir = 1
-	},
-/obj/machinery/vending/wallmed/directional/south,
-/turf/open/floor/iron/dark/textured,
-/area/station/medical/surgery/fore)
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/structure/closet/secure_closet/medical3,
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/iron/white/textured,
+/area/station/medical/storage)
 "pvO" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-10"
@@ -59240,6 +59936,13 @@
 /obj/machinery/grill,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port)
+"pxe" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/structure/sign/poster/official/random/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "pxh" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/brown{
@@ -59426,6 +60129,19 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/station/security/prison)
+"pzb" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "pzd" = (
 /obj/effect/turf_decal/bot_white/left,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -59513,6 +60229,16 @@
 /obj/structure/sink/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/commons/dorms/room3)
+"pzX" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Medbay Lobby"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/medbay/lobby)
 "pzY" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 8
@@ -59656,10 +60382,6 @@
 	dir = 8
 	},
 /area/station/hallway/floor2/aft)
-"pCo" = (
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
 "pCv" = (
 /obj/structure/chair/sofa/corp/right{
 	dir = 1
@@ -59772,6 +60494,15 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/wood/parquet,
 /area/station/maintenance/floor2/port/aft)
+"pDF" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "pDK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -59846,6 +60577,13 @@
 	dir = 8
 	},
 /area/station/hallway/floor2/fore)
+"pEN" = (
+/obj/structure/ladder,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/floor1/port)
 "pEQ" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/pod/dark,
@@ -59873,6 +60611,9 @@
 	dir = 8
 	},
 /area/station/medical/chemistry)
+"pFl" = (
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "pFu" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/effect/turf_decal/stripes/line{
@@ -59961,6 +60702,13 @@
 /obj/structure/lattice/catwalk,
 /turf/open/floor/engine/hull/reinforced,
 /area/space/nearstation)
+"pGM" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "pGR" = (
 /obj/effect/spawner/random/engineering/canister,
 /obj/effect/turf_decal/trimline/purple/warning{
@@ -60052,16 +60800,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
-"pHY" = (
-/obj/machinery/door/window/brigdoor/left/directional/south{
-	name = "Coroner's Office";
-	req_access = list("morgue_secure")
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
 "pIf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -60085,15 +60823,13 @@
 /turf/open/floor/pod,
 /area/station/maintenance/floor3/starboard)
 "pIz" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/filled/end{
+	dir = 8
 	},
-/obj/machinery/newscaster/directional/north,
+/obj/machinery/light/cold/directional/west,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/station/medical/office)
 "pIG" = (
 /obj/effect/turf_decal/tile/red/half,
 /turf/open/floor/iron/dark/side,
@@ -60541,6 +61277,11 @@
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor3/port/aft)
+"pOo" = (
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/rnd/production/techfab/department/medical,
+/turf/open/floor/iron/white/textured,
+/area/station/medical/storage)
 "pOG" = (
 /turf/closed/wall/r_wall,
 /area/station/security/eva)
@@ -60761,13 +61502,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server/upper)
-"pRQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/structure/sign/poster/official/random/directional/east,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "pRS" = (
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron/dark/side,
@@ -60942,12 +61676,15 @@
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
 "pUv" = (
-/obj/machinery/smartfridge/organ,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
+	dir = 1
 	},
-/turf/open/floor/iron/dark/textured,
-/area/station/medical/morgue)
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "pUB" = (
 /obj/machinery/power/smes{
 	charge = 5e+006
@@ -61006,8 +61743,22 @@
 /turf/open/floor/wood/parquet,
 /area/station/commons/dorms/room2)
 "pVl" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
+/obj/machinery/button/door/directional/west{
+	id = "surg_b_privacy";
+	name = "Surgery Privacy Shutters";
+	req_access = list("medical")
+	},
+/obj/machinery/light_switch/directional/west{
+	pixel_y = -10;
+	pixel_x = -24
+	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/station/medical/surgery/aft)
 "pVr" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -61036,6 +61787,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/half,
 /area/station/engineering/lobby)
+"pWe" = (
+/obj/effect/turf_decal/siding/wideplating,
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/mineral/plasma/five,
+/obj/item/clothing/glasses/science,
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/pharmacy)
 "pWf" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/reagent_dispensers/watertank/high,
@@ -61345,6 +62103,10 @@
 	},
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/floor1/fore)
+"qal" = (
+/obj/effect/turf_decal/siding/white,
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/paramedic)
 "qao" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -61465,12 +62227,6 @@
 	dir = 8
 	},
 /area/station/hallway/floor4/aft)
-"qcb" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "qcj" = (
 /obj/effect/turf_decal/trimline/green/warning{
 	dir = 6
@@ -61749,6 +62505,13 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/station/medical/abandoned)
+"qfo" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/effect/landmark/start/medical_doctor,
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/surgery/fore)
 "qfr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -61816,6 +62579,14 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/service/library/artgallery)
+"qgn" = (
+/obj/machinery/vending/wallmed/directional/north,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/camera/autoname/directional/north,
+/turf/open/floor/iron/white,
+/area/station/medical/office)
 "qgr" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 4
@@ -61942,6 +62713,8 @@
 /turf/open/misc/beach/sand,
 /area/station/hallway/floor2/fore)
 "qii" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
 "qik" = (
@@ -62183,6 +62956,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
+"qlE" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/iron/dark/side,
+/area/station/hallway/floor2/aft)
 "qlQ" = (
 /obj/machinery/light/directional/north,
 /obj/structure/sign/directions/evac/directional/north{
@@ -62200,14 +62983,14 @@
 /turf/open/floor/iron/smooth,
 /area/station/hallway/floor2/fore)
 "qlX" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /obj/structure/disposalpipe/junction{
 	dir = 2
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
@@ -62224,11 +63007,12 @@
 /turf/open/floor/carpet/red,
 /area/station/service/theater)
 "qme" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/medical/paramedic)
 "qmf" = (
 /obj/machinery/vending/security,
 /obj/machinery/light/directional/west,
@@ -62237,10 +63021,17 @@
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "qmh" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/station/medical/cryo)
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/white,
+/area/station/medical/office)
 "qmj" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -62253,11 +63044,10 @@
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor2/starboard/aft)
 "qmB" = (
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/curtain/cloth,
-/obj/structure/closet/secure_closet/personal/patient,
+/obj/structure/dresser,
+/obj/structure/sign/poster/official/random/directional/south,
 /turf/open/floor/wood/parquet,
-/area/station/medical/exam_room)
+/area/station/command/heads_quarters/cmo)
 "qmC" = (
 /obj/effect/decal/cleanable/confetti,
 /obj/effect/turf_decal/siding/blue{
@@ -62286,13 +63076,6 @@
 /obj/structure/cable,
 /turf/open/floor/carpet/neon/simple/white,
 /area/station/commons/dorms/room3)
-"qnb" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green,
-/obj/item/instrument/guitar,
-/obj/machinery/camera/autoname/directional/south,
-/turf/open/floor/carpet/royalblue,
-/area/station/command/heads_quarters/cmo)
 "qnc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -62441,13 +63224,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/floor1/port/aft)
 "qpj" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/light/cold/directional/west,
-/obj/machinery/iv_drip,
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/medical/exam_room)
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/machinery/light_switch/directional/north,
+/turf/open/floor/carpet/royalblue,
+/area/station/command/heads_quarters/cmo)
 "qpp" = (
 /obj/machinery/atmospherics/components/binary/valve/digital{
 	name = "Waste Release"
@@ -62455,14 +63240,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"qpr" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/turf/open/floor/iron/white/side,
-/area/station/medical/medbay/lobby)
 "qpt" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -62494,9 +63271,12 @@
 /turf/open/floor/wood/large,
 /area/station/security/prison/safe)
 "qqr" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/medical/storage)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white,
+/area/station/medical/office)
 "qqu" = (
 /obj/machinery/light/broken/directional/north,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -62955,14 +63735,10 @@
 /turf/open/floor/iron/textured_large,
 /area/station/cargo/sorting)
 "qvR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/blue/arrow_cw{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/cryo)
 "qwc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -63367,6 +64143,13 @@
 /obj/effect/turf_decal/trimline/red/corner,
 /turf/open/floor/pod/dark,
 /area/station/hallway/secondary/entry)
+"qAn" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white,
+/area/station/medical/storage)
 "qAq" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -63525,19 +64308,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/secondary/exit/escape_pod)
-"qBQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/mail_sorting/medbay/chemistry,
-/obj/effect/mapping_helpers/mail_sorting/medbay/cmo_office,
-/obj/effect/mapping_helpers/mail_sorting/medbay/general,
-/obj/effect/mapping_helpers/mail_sorting/medbay/virology,
-/turf/open/floor/iron/dark/side,
-/area/station/hallway/floor2/aft)
 "qBR" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /obj/structure/cable,
@@ -63871,10 +64641,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/floor2/port/aft)
 "qEQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/effect/turf_decal/siding/wideplating,
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 1
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/medbay/central)
 "qFa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -64299,6 +65072,14 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/starboard)
+"qKw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/sign/departments/medbay/alt/directional/south,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "qKG" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -64323,9 +65104,10 @@
 /turf/open/floor/iron,
 /area/station/maintenance/floor2/starboard/fore)
 "qLu" = (
-/obj/item/radio/intercom/directional/west,
-/obj/structure/table,
-/obj/item/storage/medkit/regular,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "qLH" = (
@@ -64391,15 +65173,16 @@
 /area/station/science/server)
 "qMT" = (
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/item/radio/intercom/directional/north,
-/obj/machinery/light/cold/directional/north,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/station/medical/office)
 "qMV" = (
 /obj/machinery/atmospherics/components/unary/portables_connector,
 /obj/effect/turf_decal/bot,
@@ -65030,18 +65813,15 @@
 "qUv" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/structure/closet/secure_closet/chemical,
-/obj/machinery/airalarm/directional/south,
 /obj/machinery/light/cold/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "qUE" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/blood/drip,
-/obj/structure/sink/directional/west,
-/turf/open/floor/iron/white,
-/area/station/medical/storage)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/turf_decal/siding/white,
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/cryo)
 "qUL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -65059,10 +65839,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/lower)
-"qUQ" = (
-/obj/structure/sign/departments/psychology,
-/turf/closed/wall,
-/area/station/maintenance/floor1/port)
 "qUV" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -65334,12 +66110,26 @@
 	},
 /turf/open/floor/plating,
 /area/station/security/eva)
+"qYH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "qYQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/floor3/fore)
+"qYW" = (
+/obj/structure/bed/roller,
+/obj/machinery/iv_drip,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "qZc" = (
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 8
@@ -65495,7 +66285,7 @@
 /obj/structure/railing/corner{
 	dir = 8
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/dark,
 /area/station/medical/psychology)
 "rbh" = (
 /obj/structure/railing,
@@ -65810,15 +66600,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/hallway/floor4/aft)
-"reA" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/machinery/airalarm/directional/west,
-/obj/machinery/iv_drip,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/medical/exam_room)
 "reC" = (
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
@@ -65890,7 +66671,7 @@
 	dir = 4
 	},
 /obj/structure/sign/poster/official/random/directional/west,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/dark,
 /area/station/medical/psychology)
 "rfD" = (
 /obj/effect/turf_decal/stripes/line{
@@ -65925,6 +66706,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/tile,
 /area/station/service/library)
+"rfS" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "rfT" = (
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /obj/structure/cable,
@@ -66016,11 +66806,6 @@
 	dir = 4
 	},
 /area/station/hallway/secondary/exit/departure_lounge)
-"rgS" = (
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/machinery/medical_kiosk,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
 "rgT" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 10
@@ -66054,22 +66839,11 @@
 /turf/open/floor/iron/dark,
 /area/station/cargo/lobby)
 "rhI" = (
-/obj/item/storage/backpack/duffelbag/med/surgery{
-	pixel_y = 13
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
 	},
-/obj/item/reagent_containers/medigel/sterilizine{
-	pixel_x = 1
-	},
-/obj/item/reagent_containers/syringe{
-	pixel_x = -7
-	},
-/obj/item/stack/medical/bone_gel{
-	pixel_x = 10
-	},
-/obj/effect/turf_decal/box/white,
-/obj/structure/table/reinforced/rglass,
-/turf/open/floor/iron/dark/textured,
-/area/station/medical/surgery/fore)
+/turf/open/floor/iron/white,
+/area/station/medical/storage)
 "rhJ" = (
 /obj/structure/railing{
 	dir = 4
@@ -66126,11 +66900,13 @@
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor4/starboard/aft)
 "rip" = (
-/obj/effect/turf_decal/tile/blue/full,
-/obj/structure/closet/crate/freezer/blood,
-/obj/structure/sign/poster/official/random/directional/east,
-/turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "riy" = (
 /obj/effect/turf_decal/trimline/yellow/warning,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -66174,28 +66950,24 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/starboard/fore)
+"riS" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Maintenance Access"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/access/any/medical/morgue,
+/obj/machinery/duct,
+/turf/open/floor/plating,
+/area/station/maintenance/floor2/port)
 "riT" = (
 /obj/effect/decal/cleanable/ash/large,
 /turf/open/floor/plating,
 /area/station/maintenance/floor1/port/aft)
-"rja" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/junction{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
-"rjf" = (
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/structure/hedge,
-/obj/machinery/camera/autoname/directional/west,
-/turf/open/floor/iron/white,
-/area/station/command/heads_quarters/cmo)
 "rjh" = (
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 4
@@ -66216,6 +66988,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor1/aft)
+"rjt" = (
+/obj/structure/bed{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/structure/sign/poster/official/random/directional/east,
+/turf/open/floor/iron/white/textured,
+/area/station/medical/office)
 "rjD" = (
 /turf/closed/wall,
 /area/station/hallway/floor1/aft)
@@ -66448,12 +67228,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor2/starboard/fore)
-"rof" = (
-/obj/machinery/iv_drip,
-/obj/structure/mirror/directional/south,
-/obj/structure/sign/poster/official/cleanliness/directional/east,
-/turf/open/floor/iron/dark,
-/area/station/medical/surgery/aft)
 "rog" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -66709,7 +67483,9 @@
 /obj/effect/turf_decal/tile/green/full,
 /obj/machinery/light/directional/east,
 /obj/structure/table/reinforced,
-/obj/item/instrument/musicalmoth,
+/obj/item/instrument/musicalmoth{
+	name = "Congo Ralis"
+	},
 /obj/item/clothing/head/mothcap,
 /turf/open/floor/iron/smooth_large,
 /area/station/hallway/secondary/entry)
@@ -66764,6 +67540,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/office)
+"rsq" = (
+/obj/structure/railing/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "rsr" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -66778,14 +67562,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/green,
 /area/station/service/abandoned_gambling_den)
-"rsH" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/blood/old,
-/obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
 "rsI" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Security - Cell"
@@ -66906,15 +67682,14 @@
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor2/starboard/fore)
 "rue" = (
-/obj/structure/extinguisher_cabinet/directional/south,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/corner{
+/obj/structure/railing{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/obj/machinery/duct,
+/turf/open/floor/iron/stairs/right{
+	dir = 1
+	},
+/area/station/command/heads_quarters/cmo)
 "ruo" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
@@ -67055,13 +67830,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
-"rwV" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
 "rwY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/modular_computer/console/preset/civilian{
@@ -67208,13 +67976,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/floor4/starboard)
 "ryV" = (
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/structure/chair/comfy/teal{
+/obj/effect/turf_decal/tile/blue/full,
+/obj/structure/table/glass,
+/obj/item/storage/medkit/emergency,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/turf/open/floor/iron/white/textured,
+/area/station/medical/treatment_center)
 "ryX" = (
 /obj/structure/railing/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -67532,9 +68301,14 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor1/fore)
 "rDu" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
-/turf/open/floor/iron/dark/textured,
-/area/station/medical/cryo)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "rDw" = (
 /turf/open/floor/iron/dark/side{
 	dir = 4
@@ -67601,14 +68375,9 @@
 /turf/open/floor/plating,
 /area/station/security/brig)
 "rEg" = (
-/obj/structure/table/wood,
-/obj/effect/turf_decal/siding/wood,
 /obj/item/radio/intercom/directional/east,
-/obj/machinery/fax{
-	fax_name = "Psychology Office";
-	name = "Psychology Office Fax Machine"
-	},
-/turf/open/floor/carpet,
+/obj/structure/bookcase/random/nonfiction,
+/turf/open/floor/wood/parquet,
 /area/station/medical/psychology)
 "rEi" = (
 /obj/machinery/light/directional/east,
@@ -67846,6 +68615,14 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor3/port)
+"rID" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/structure/closet/firecloset,
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "rIK" = (
 /obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/iron/dark,
@@ -67874,6 +68651,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor3/port/aft)
 "rJb" = (
@@ -67891,7 +68669,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/structure/sign/poster/official/random/directional/south,
 /turf/open/floor/iron/white,
 /area/station/hallway/floor2/aft)
 "rJp" = (
@@ -67974,14 +68751,20 @@
 /turf/open/floor/carpet,
 /area/station/service/lawoffice)
 "rKy" = (
-/obj/machinery/light/small/directional/north,
-/obj/structure/table/reinforced/rglass,
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "med_doors";
+	name = "Medbay"
 	},
-/turf/open/floor/iron/dark/textured,
-/area/station/medical/morgue)
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/effect/mapping_helpers/airlock/access/any/medical/general,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white/textured,
+/area/station/medical/medbay/lobby)
 "rKB" = (
 /obj/structure/railing{
 	dir = 9
@@ -68071,13 +68854,6 @@
 /obj/structure/bookcase/random,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
-"rLi" = (
-/obj/machinery/camera/autoname/directional/south,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/medical/cryo)
 "rLs" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/dark,
@@ -68289,14 +69065,6 @@
 "rPi" = (
 /turf/closed/wall,
 /area/station/cargo/office)
-"rPq" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/item/radio/intercom/directional/south,
-/obj/machinery/light/cold/directional/south,
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
 "rPw" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
@@ -68402,15 +69170,18 @@
 /turf/open/floor/iron,
 /area/station/hallway/floor3/aft)
 "rQo" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+/obj/structure/table/glass,
+/obj/item/storage/box/masks{
+	pixel_x = -5;
+	pixel_y = 3
 	},
-/obj/effect/turf_decal/trimline/blue/arrow_cw{
-	dir = 1
+/obj/item/storage/box/gloves{
+	pixel_x = 5;
+	pixel_y = 3
 	},
-/obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/white/textured,
+/area/station/medical/office)
 "rQx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -68428,6 +69199,7 @@
 	dir = 4
 	},
 /obj/structure/table/wood,
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/carpet/royalblue,
 /area/station/medical/break_room)
 "rRd" = (
@@ -68473,16 +69245,6 @@
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor4/starboard)
-"rRH" = (
-/obj/machinery/computer/operating{
-	dir = 8
-	},
-/obj/machinery/camera/autoname/directional/north,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/medical/morgue)
 "rRP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -68553,16 +69315,6 @@
 	icon_state = "snow1"
 	},
 /area/station/maintenance/floor2/port/aft)
-"rSx" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white,
-/area/station/command/heads_quarters/cmo)
 "rSC" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer2{
 	dir = 4
@@ -68741,20 +69493,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor1/fore)
-"rUP" = (
-/obj/effect/mapping_helpers/airlock/access/all/medical/pharmacy,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/medical/glass{
-	name = "Pharmacy"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/noslip,
-/area/station/medical/pharmacy)
 "rUW" = (
 /obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/trimline/yellow,
@@ -68835,13 +69573,8 @@
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/rd)
 "rXa" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/machinery/vending/clothing,
-/obj/item/radio/intercom/directional/south,
-/turf/open/floor/iron/white,
-/area/station/medical/exam_room)
+/turf/closed/wall/r_wall,
+/area/station/command/heads_quarters/cmo)
 "rXp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/random/directional/north,
@@ -69118,14 +69851,6 @@
 /obj/effect/spawner/random/entertainment/cigarette_pack,
 /turf/open/floor/iron,
 /area/station/maintenance/floor4/starboard)
-"sbZ" = (
-/obj/structure/table/wood,
-/obj/machinery/fax{
-	fax_name = "Chief Medical Officer's Office";
-	name = "Chief Medical Officer's Fax Machine"
-	},
-/turf/open/floor/wood/parquet,
-/area/station/command/heads_quarters/cmo)
 "scc" = (
 /obj/structure/fluff/paper/stack{
 	desc = "A stack of various papers, absolutely unreadable due to scorch marks and aging."
@@ -69400,17 +70125,16 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor3/fore)
-"sgi" = (
-/obj/structure/industrial_lift/public,
-/obj/effect/landmark/lift_id{
-	specific_lift_id = "com_vator"
+"sgd" = (
+/obj/structure/cable,
+/obj/machinery/door/window/brigdoor/left/directional/south{
+	name = "Coroner's Office";
+	req_access = list("morgue_secure")
 	},
-/obj/effect/abstract/elevator_music_zone{
-	linked_elevator_id = "com_vator";
-	range = 2
-	},
-/turf/open/floor/plating/elevatorshaft,
-/area/station/hallway/floor3/fore)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "sgH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/structure/table_or_rack,
@@ -69461,7 +70185,7 @@
 /obj/machinery/camera/autoname/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/dark,
 /area/station/medical/psychology)
 "shB" = (
 /obj/structure/reagent_dispensers/plumbed,
@@ -69697,10 +70421,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/medical/treatment_center)
-"slQ" = (
-/obj/machinery/vending/medical,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "smf" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -69966,16 +70686,15 @@
 /turf/open/floor/carpet/red,
 /area/station/service/theater)
 "sqt" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
+/obj/structure/table/reinforced/rglass,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/door/firedoor,
+/obj/structure/desk_bell{
+	pixel_x = 7
 	},
-/obj/machinery/button/door/directional/south{
-	id = "med_doors";
-	name = "Medbay Door Control";
-	normaldoorcontrol = 1;
-	req_access = list("medical")
-	},
-/turf/open/floor/iron/white,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/medbay/lobby)
 "sqv" = (
 /obj/structure/railing,
@@ -70032,11 +70751,14 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
 "srH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/camera/autoname/directional/west,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/duct,
+/turf/open/floor/iron/white/textured,
+/area/station/medical/cryo)
 "srO" = (
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /obj/machinery/door/airlock/hatch{
@@ -70301,20 +71023,27 @@
 	dir = 8
 	},
 /area/station/engineering/lobby)
-"svm" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
 "svp" = (
-/obj/structure/hedge,
+/obj/item/storage/medkit/brute{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/storage/medkit/brute,
+/obj/item/storage/medkit/brute{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/structure/table/reinforced,
+/obj/item/storage/medkit/regular,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/window/right/directional/south{
+	name = "First Aid Supplies";
+	req_access = list("medical")
+	},
 /obj/effect/turf_decal/tile/blue/fourcorners,
-/turf/open/floor/iron/white,
-/area/station/command/heads_quarters/cmo)
+/turf/open/floor/iron/white/textured,
+/area/station/medical/storage)
 "svs" = (
 /obj/machinery/vending/wallmed/directional/west,
 /turf/open/floor/iron/dark/side{
@@ -70350,7 +71079,7 @@
 "svL" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters{
+/obj/machinery/door/poddoor/shutters/preopen{
 	id = "viro-inner";
 	name = "Virology Inner Shutters"
 	},
@@ -70388,6 +71117,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/smooth_edge,
 /area/station/science/research/abandoned)
+"swl" = (
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/curtain/cloth,
+/obj/structure/closet/secure_closet/personal/patient,
+/turf/open/floor/wood/parquet,
+/area/station/medical/patients_rooms)
 "swm" = (
 /obj/machinery/air_sensor/nitrogen_tank,
 /obj/effect/turf_decal/trimline/red/line,
@@ -70758,6 +71493,16 @@
 	dir = 1
 	},
 /area/station/hallway/floor1/aft)
+"sAV" = (
+/obj/machinery/door/airlock/medical{
+	name = "CMO Quarters"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/cmo,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
+/turf/open/floor/wood/parquet,
+/area/station/command/heads_quarters/cmo)
 "sBb" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -70767,6 +71512,14 @@
 /obj/machinery/light/cold/no_nightlight/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/second)
+"sBj" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/office)
 "sBp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -70852,14 +71605,15 @@
 /turf/open/floor/wood,
 /area/station/service/theater)
 "sCs" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "cmo_privacy";
+	name = "CMO Privacy Shutters"
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/command/heads_quarters/cmo)
 "sCu" = (
 /obj/effect/turf_decal/trimline/purple/corner{
 	dir = 4
@@ -70875,6 +71629,13 @@
 /obj/item/kirbyplants/photosynthetic,
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor4/starboard)
+"sCJ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/camera/autoname/directional/south,
+/turf/open/floor/iron/dark/side,
+/area/station/hallway/floor2/aft)
 "sDo" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -71027,6 +71788,14 @@
 /obj/structure/sign/nanotrasen,
 /turf/closed/wall/r_wall,
 /area/station/command/bridge)
+"sGn" = (
+/obj/machinery/light/cold/directional/east,
+/obj/machinery/newscaster/directional/east,
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/surgery/aft)
 "sGu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -71182,17 +71951,11 @@
 /turf/open/floor/pod,
 /area/station/maintenance/floor4/starboard/aft)
 "sHX" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/blue/arrow_cw{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/cryo_cell{
+	dir = 4
 	},
-/obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/cryo)
 "sHY" = (
 /obj/effect/turf_decal/tile/red/half,
 /obj/machinery/duct,
@@ -71223,6 +71986,11 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/cytology)
+"sIk" = (
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/computer/records/medical,
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/paramedic)
 "sIr" = (
 /obj/machinery/light/small/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -71333,14 +72101,8 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor3/fore)
 "sJT" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white/side{
-	dir = 8
-	},
-/area/station/medical/medbay/lobby)
+/turf/closed/wall/r_wall,
+/area/station/medical/paramedic)
 "sJU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -71436,9 +72198,12 @@
 /turf/open/floor/pod/light,
 /area/station/maintenance/solars/port/aft)
 "sKY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "sKZ" = (
@@ -71626,15 +72391,6 @@
 	dir = 1
 	},
 /area/station/hallway/floor2/aft)
-"sOd" = (
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/command/heads_quarters/cmo)
 "sOj" = (
 /obj/effect/spawner/random/structure/girder,
 /turf/open/floor/pod/light,
@@ -71742,6 +72498,15 @@
 	},
 /turf/open/floor/wood/tile,
 /area/station/service/library/lounge)
+"sPx" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/structure/chair/plastic,
+/obj/structure/sign/poster/official/random/directional/north,
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "sPJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -71916,6 +72681,16 @@
 /obj/item/multitool,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port/fore)
+"sSL" = (
+/obj/machinery/smartfridge/chemistry/preloaded,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "chem-lock-a";
+	name = "Chemistry Shutters"
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/pharmacy)
 "sSO" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/structure/cable,
@@ -71929,8 +72704,10 @@
 /obj/effect/turf_decal/trimline/blue/warning{
 	dir = 6
 	},
-/obj/effect/spawner/random/structure/closet_maintenance,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/plumbed{
+	dir = 1
+	},
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor2/port)
 "sSR" = (
@@ -71942,12 +72719,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/checker,
 /area/station/commons/vacant_room/commissary)
-"sSU" = (
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white/side{
-	dir = 8
-	},
-/area/station/medical/medbay/lobby)
 "sSV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -71972,15 +72743,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint)
-"sTy" = (
-/obj/effect/turf_decal/trimline/blue/warning{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/maintenance,
-/obj/structure/grille/broken,
-/turf/open/floor/pod/dark,
-/area/station/maintenance/floor2/port)
 "sTC" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -72168,7 +72930,7 @@
 "sVw" = (
 /obj/machinery/smartfridge,
 /obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/poddoor/shutters{
+/obj/machinery/door/poddoor/shutters/preopen{
 	id = "viro-inner";
 	name = "Virology Inner Shutters"
 	},
@@ -72422,11 +73184,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor3/aft)
-"sYd" = (
-/obj/machinery/light/cold/directional/east,
-/obj/machinery/newscaster/directional/east,
-/turf/open/floor/iron/dark/textured,
-/area/station/medical/surgery/aft)
 "sYf" = (
 /turf/open/floor/engine/plasma,
 /area/station/engineering/atmos)
@@ -72440,13 +73197,13 @@
 /turf/open/floor/iron,
 /area/station/science/lobby)
 "sYk" = (
-/obj/effect/turf_decal/trimline/blue/end,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/shower/directional/south,
-/turf/open/floor/iron/dark/textured,
-/area/station/medical/cryo)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "sYl" = (
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/disposal/bin,
@@ -72503,12 +73260,18 @@
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor1/port)
 "sYS" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/railing/corner{
+	dir = 1
 	},
-/turf/open/floor/iron/dark/textured,
-/area/station/medical/morgue)
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "sYU" = (
 /obj/machinery/space_heater,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -72560,8 +73323,11 @@
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "sZx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/textured,
-/area/station/medical/surgery/aft)
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/medical/office)
 "sZy" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
@@ -72621,12 +73387,11 @@
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "sZT" = (
-/obj/structure/cable,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/medical/cryo)
+/obj/machinery/vending/drugs,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/structure/sign/poster/official/random/directional/south,
+/turf/open/floor/iron/white/textured,
+/area/station/medical/medbay/central)
 "sZX" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 6
@@ -72774,6 +73539,15 @@
 	},
 /turf/open/floor/carpet/neon/simple/pink/nodots,
 /area/station/maintenance/floor2/port/fore)
+"tbQ" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/firealarm/directional/west,
+/obj/structure/sink/directional/east,
+/obj/machinery/light/cold/directional/west,
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "tbX" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -72784,9 +73558,6 @@
 	dir = 9
 	},
 /area/station/security/brig)
-"tca" = (
-/turf/open/floor/wood/parquet,
-/area/station/medical/break_room)
 "tch" = (
 /obj/machinery/autolathe,
 /obj/machinery/camera/autoname/directional/south,
@@ -72983,15 +73754,6 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor3/fore)
-"teP" = (
-/obj/machinery/door/airlock/medical{
-	name = "Morgue"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/any/medical/morgue,
-/turf/open/floor/iron/white,
-/area/station/medical/morgue)
 "teQ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -73055,7 +73817,8 @@
 /area/station/maintenance/floor2/port/fore)
 "tfV" = (
 /obj/effect/turf_decal/stripes,
-/turf/open/floor/iron/white,
+/obj/structure/sign/departments/psychology/directional/west,
+/turf/open/floor/iron/dark,
 /area/station/medical/psychology)
 "tgc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
@@ -73065,14 +73828,6 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/station/hallway/floor1/aft)
-"tgj" = (
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/structure/table/glass,
-/obj/item/bonesetter,
-/obj/item/stack/medical/bone_gel/four,
-/obj/structure/sign/departments/medbay/alt/directional/south,
-/turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
 "tgq" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
@@ -73193,11 +73948,11 @@
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port/fore)
 "tiG" = (
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/turf/open/floor/iron/dark/textured,
-/area/station/medical/cryo)
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "tiN" = (
 /obj/structure/railing{
 	dir = 8
@@ -73215,14 +73970,6 @@
 	dir = 1
 	},
 /area/station/command/heads_quarters/cmo)
-"tiT" = (
-/obj/structure/extinguisher_cabinet/directional/south,
-/obj/effect/turf_decal/trimline/blue/arrow_cw{
-	dir = 1
-	},
-/obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "tiX" = (
 /obj/effect/turf_decal/trimline/green/warning{
 	dir = 10
@@ -73270,6 +74017,15 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/exit/escape_pod)
+"tjk" = (
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal/bin,
+/obj/machinery/light/cold/directional/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "tjq" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -73381,22 +74137,6 @@
 	},
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor4/port/aft)
-"tkU" = (
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/effect/mapping_helpers/airlock/access/any/medical/general,
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/junction/flip{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 4
-	},
-/obj/machinery/door/airlock/medical/glass{
-	name = "Treatment Center"
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
 "tld" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/mineral/plasma/five,
@@ -73468,11 +74208,11 @@
 /turf/open/space/openspace,
 /area/space)
 "tlT" = (
-/obj/structure/bed/roller,
-/obj/machinery/iv_drip,
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron/dark/textured,
-/area/station/medical/morgue)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "tlX" = (
 /obj/machinery/modular_computer/console/preset/civilian{
 	dir = 8
@@ -73662,12 +74402,12 @@
 	},
 /area/station/engineering/lobby)
 "tog" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
+/obj/structure/chair/office/tactical{
+	dir = 1
+	},
+/obj/effect/landmark/start/coroner,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "toh" = (
 /obj/machinery/holopad,
 /obj/structure/sign/poster/official/random/directional/north,
@@ -73879,11 +74619,9 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
 "trn" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "trq" = (
@@ -74043,9 +74781,13 @@
 /turf/open/floor/iron/white,
 /area/station/medical/abandoned)
 "ttZ" = (
-/obj/structure/sign/poster/contraband/moffuchis_pizza/directional/east,
-/turf/open/floor/carpet/royalblue,
-/area/station/medical/break_room)
+/obj/structure/sink/directional/south,
+/obj/structure/mirror/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/wood/parquet,
+/area/station/command/heads_quarters/cmo)
 "tua" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -74138,6 +74880,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/floor2/fore)
+"tuY" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/turf/open/floor/catwalk_floor,
+/area/station/maintenance/floor1/port)
 "tve" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -74841,6 +75591,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor4/aft)
+"tFE" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/dark/side,
+/area/station/hallway/floor2/aft)
 "tFK" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 5
@@ -75122,10 +75882,6 @@
 	dir = 5
 	},
 /area/station/hallway/floor2/aft)
-"tJC" = (
-/obj/machinery/light/cold/no_nightlight/directional/west,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "tJE" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -75242,6 +75998,37 @@
 /obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/station/science/genetics)
+"tKE" = (
+/obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/structure/table/glass,
+/obj/item/paper_bin,
+/obj/item/folder/white{
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/obj/item/folder/white{
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/obj/item/folder/white{
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/obj/item/pen/red{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/pen{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/pen/blue{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/turf/open/floor/iron/white/textured,
+/area/station/medical/office)
 "tKJ" = (
 /obj/item/storage/toolbox/electrical{
 	pixel_y = 10
@@ -75350,9 +76137,16 @@
 "tMo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white,
-/area/station/command/heads_quarters/cmo)
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/medbay/central)
 "tMp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -75408,6 +76202,18 @@
 /obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor,
 /area/station/hallway/floor1/fore)
+"tNL" = (
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/effect/mapping_helpers/airlock/access/any/medical/general,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Treatment Center"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/medical/office)
 "tNO" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -75466,6 +76272,16 @@
 	dir = 1
 	},
 /area/station/hallway/floor1/aft)
+"tOE" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/machinery/vending/wallmed/directional/north,
+/obj/machinery/duct,
+/obj/item/stack/medical/gauze,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "tOP" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -75532,6 +76348,14 @@
 	dir = 4
 	},
 /area/station/ai_monitored/command/storage/eva)
+"tPw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "tPx" = (
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/dark,
@@ -75587,15 +76411,10 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor2/aft)
 "tQu" = (
-/obj/structure/chair/comfy/brown{
-	dir = 4
-	},
-/obj/effect/landmark/start/medical_doctor,
-/obj/item/radio/intercom/directional/south,
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/turf/open/floor/carpet/royalblue,
+/obj/machinery/microwave,
+/obj/structure/table/reinforced/rglass,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/white/textured,
 /area/station/medical/break_room)
 "tQF" = (
 /obj/structure/disposalpipe/segment{
@@ -75995,10 +76814,17 @@
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/captain/private)
 "tWV" = (
-/obj/machinery/light/cold/directional/east,
-/obj/machinery/newscaster/directional/east,
-/turf/open/floor/iron/dark/textured,
-/area/station/medical/surgery/fore)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/storage)
 "tWX" = (
 /obj/effect/turf_decal/stripes,
 /obj/structure/emergency_shield/regenerating,
@@ -76048,6 +76874,10 @@
 /obj/structure/sign/poster/official/random/directional/south,
 /turf/open/floor/wood/tile,
 /area/station/service/library)
+"tXY" = (
+/obj/effect/spawner/random/engineering/atmospherics_portable,
+/turf/open/floor/pod/dark,
+/area/station/maintenance/floor2/port)
 "tYc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
@@ -76301,11 +77131,18 @@
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
 "ucd" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+/obj/item/radio/intercom/directional/north,
+/obj/structure/table/reinforced/rglass,
+/obj/item/storage/medkit/emergency{
+	pixel_x = -4
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/obj/item/storage/medkit/emergency,
+/obj/item/storage/medkit/emergency{
+	pixel_x = 4
+	},
+/obj/effect/turf_decal/siding/white,
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/paramedic)
 "ucf" = (
 /obj/effect/turf_decal/tile/blue/anticorner,
 /turf/open/floor/iron/textured_corner{
@@ -76422,6 +77259,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/floor2/aft)
 "udx" = (
@@ -76527,14 +77365,13 @@
 /turf/open/floor/wood,
 /area/station/commons/vacant_room/office)
 "ueN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/medical/pharmacy,
 /obj/machinery/door/airlock/hatch{
 	name = "Maintenance Access"
 	},
-/turf/open/floor/plating,
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/medical/psychology,
+/turf/open/floor/catwalk_floor,
 /area/station/hallway/floor2/fore)
 "ueO" = (
 /obj/machinery/disposal/bin,
@@ -76580,9 +77417,15 @@
 /turf/open/floor/plating,
 /area/station/medical/abandoned)
 "ufA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/textured,
-/area/station/medical/surgery/fore)
+/obj/item/wrench/medical,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
+/obj/structure/table/glass,
+/obj/item/gun/syringe,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/white/textured,
+/area/station/medical/storage)
 "ufI" = (
 /obj/machinery/firealarm/directional/south,
 /obj/machinery/camera/directional/south{
@@ -76907,15 +77750,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/textured,
 /area/station/cargo/storage)
-"ujG" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/medical/exam_room)
 "ujI" = (
 /obj/structure/railing,
 /turf/open/space/openspace,
@@ -76999,6 +77833,19 @@
 	dir = 1
 	},
 /area/station/medical/abandoned)
+"ulf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "ulh" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/cigarettes/cigpack_uplift{
@@ -77052,6 +77899,12 @@
 /obj/structure/hedge,
 /turf/open/floor/carpet/green,
 /area/station/service/kitchen/diner)
+"ulI" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/surgery/fore)
 "ulN" = (
 /obj/structure/chair/pew{
 	dir = 1
@@ -77210,10 +78063,11 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "uon" = (
-/obj/item/radio/intercom/directional/north,
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "uov" = (
@@ -77296,6 +78150,14 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/bar/atrium)
+"upX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/medical/office)
 "uqc" = (
 /turf/closed/wall/r_wall,
 /area/station/command/teleporter)
@@ -77460,12 +78322,8 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
 "usG" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
+/obj/structure/table/wood,
+/obj/item/storage/box/donkpockets,
 /turf/open/floor/wood/parquet,
 /area/station/medical/break_room)
 "usI" = (
@@ -77558,16 +78416,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/lawoffice)
-"utM" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "utT" = (
 /obj/structure/hedge/opaque,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -77598,11 +78446,13 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor4/aft)
 "uur" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/medical/paramedic)
 "uuu" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -77764,6 +78614,15 @@
 "uwU" = (
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
+"uwV" = (
+/obj/structure/cable,
+/obj/structure/bed/dogbed/runtime,
+/mob/living/simple_animal/pet/cat/runtime,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/station/command/heads_quarters/cmo)
 "uxf" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional,
 /obj/structure/cable,
@@ -77821,7 +78680,9 @@
 /obj/effect/turf_decal/trimline/blue/warning{
 	dir = 10
 	},
-/obj/effect/spawner/random/structure/tank_holder,
+/obj/structure/reagent_dispensers/plumbed{
+	dir = 1
+	},
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor2/port)
 "uxR" = (
@@ -78019,20 +78880,12 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/exit/escape_pod)
-"uAI" = (
-/obj/machinery/light/cold/directional/south,
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/effect/turf_decal/trimline/blue/arrow_cw{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "uAT" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/cryo)
 "uAU" = (
 /obj/machinery/light/directional/west,
 /obj/structure/table/reinforced,
@@ -78143,6 +78996,14 @@
 /obj/machinery/vending/boozeomat,
 /turf/open/floor/wood,
 /area/station/command/meeting_room)
+"uCO" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/office)
 "uCP" = (
 /turf/open/floor/wood/large,
 /area/station/service/library/artgallery)
@@ -78331,6 +79192,11 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor3/starboard)
+"uFd" = (
+/obj/structure/table/optable,
+/obj/machinery/defibrillator_mount/directional/south,
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/surgery/aft)
 "uFh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -78627,6 +79493,14 @@
 /obj/machinery/light/red/dim/directional/east,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor2/starboard/aft)
+"uJu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "uJA" = (
 /obj/structure/table/glass,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -78686,21 +79560,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor2/port/fore)
-"uKm" = (
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/structure/table,
-/obj/item/book/fish_catalog,
-/obj/item/book/manual/wiki/ordnance{
-	pixel_x = -6;
-	pixel_y = -2
-	},
-/obj/item/book/manual/wiki/detective{
-	pixel_x = 6;
-	pixel_y = 2
-	},
-/obj/machinery/light/cold/directional/west,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
 "uKn" = (
 /obj/structure/stairs/north,
 /turf/open/floor/plating,
@@ -78946,13 +79805,12 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor3/fore)
 "uNB" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Maintenance Access"
+/obj/effect/turf_decal/delivery/white{
+	color = "#52B4E9"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/medical/general,
-/obj/machinery/duct,
-/turf/open/floor/pod/light,
-/area/station/maintenance/floor2/port)
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/morgue)
 "uNC" = (
 /obj/effect/turf_decal/trimline/green/filled/corner,
 /obj/structure/sign/poster/official/random/directional/west,
@@ -79167,13 +80025,12 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/floor2/starboard/aft)
 "uQk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /obj/machinery/duct,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/station/medical/treatment_center)
 "uQo" = (
 /obj/structure/sign/poster/official/random/directional/south,
 /obj/structure/disposalpipe/segment{
@@ -79350,10 +80207,13 @@
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor1/starboard)
 "uST" = (
-/obj/structure/table/optable,
-/obj/machinery/defibrillator_mount/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/medical/surgery/aft)
+/obj/structure/bed{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/iron/white/textured,
+/area/station/medical/office)
 "uSW" = (
 /obj/machinery/ticket_machine/directional/north,
 /obj/effect/landmark/navigate_destination/hop,
@@ -79474,7 +80334,12 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor2/fore)
 "uUA" = (
-/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/poddoor/preopen{
+	elevator_linked_id = "com_vator";
+	elevator_mode = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor2/fore)
 "uUE" = (
@@ -79545,17 +80410,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/chapel,
 /area/station/service/chapel)
-"uVl" = (
-/obj/effect/mapping_helpers/airlock/access/any/medical/general,
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "med_doors";
-	name = "Medical Front Door"
-	},
-/obj/effect/mapping_helpers/airlock/unres,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
 "uVr" = (
 /obj/effect/turf_decal/trimline/red/line{
 	dir = 1
@@ -79695,6 +80549,17 @@
 /obj/structure/falsewall,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/service/kitchen/abandoned)
+"uXd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/obj/machinery/duct,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/aft)
 "uXf" = (
 /obj/structure/sign/poster/official/random/directional/north,
 /obj/machinery/camera/autoname/directional/north,
@@ -79913,18 +80778,10 @@
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor4/starboard)
 "uZz" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/duct,
-/obj/machinery/button/door/directional/west{
-	id = "surg_b_privacy";
-	name = "Surgery Privacy Shutters";
-	req_access = list("medical")
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/surgery/aft)
+/turf/open/floor/plating,
+/area/station/medical/office)
 "uZF" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/floor2/starboard/aft)
@@ -80277,6 +81134,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/unres,
+/obj/effect/mapping_helpers/airlock/access/any/medical/morgue,
 /turf/open/floor/plating,
 /area/station/maintenance/floor2/port)
 "vfi" = (
@@ -80355,15 +81213,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/incinerator)
-"vgy" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/department/medical)
 "vgH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -80384,11 +81233,12 @@
 /turf/open/floor/plating,
 /area/station/service/kitchen)
 "vhf" = (
-/obj/structure/sign/poster/official/plasma_effects/directional/east,
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/machinery/suit_storage_unit/medical,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
-/area/station/medical/storage)
+/area/station/medical/medbay/aft)
 "vhj" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -80456,12 +81306,11 @@
 /area/station/hallway/floor4/fore)
 "vib" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/structure/extinguisher_cabinet/directional/south,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 10
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
@@ -80474,19 +81323,6 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/iron,
 /area/station/commons/fitness)
-"vix" = (
-/obj/effect/mapping_helpers/airlock/access/all/medical/cmo,
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/medical{
-	name = "CMO Office"
-	},
-/turf/open/floor/iron/white,
-/area/station/command/heads_quarters/cmo)
 "viA" = (
 /obj/machinery/door/morgue{
 	name = "Confession Booth"
@@ -80755,17 +81591,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/station/cargo/miningdock)
-"vmj" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
 "vmp" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/status_display/ai/directional/east,
@@ -80902,6 +81727,17 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/station/command/meeting_room)
+"vnQ" = (
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/structure/table/glass,
+/obj/item/storage/box/masks,
+/obj/item/storage/box/bodybags{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/structure/sign/departments/medbay/alt/directional/west,
+/turf/open/floor/iron/white/textured,
+/area/station/medical/treatment_center)
 "vnR" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
@@ -81092,7 +81928,10 @@
 /area/station/science/cytology)
 "vpU" = (
 /obj/structure/rack,
-/obj/item/toy/plush/plasmamanplushie,
+/obj/item/toy/plush/plasmamanplushie{
+	name = "Nitrous II";
+	desc = "A stuffed toy that resembles your plasma coworkers. It is cute despite itself."
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/floor1/port/fore)
 "vqb" = (
@@ -81611,13 +82450,6 @@
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port)
-"vwv" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/disposal/bin,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "vwB" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/grille/broken,
@@ -81731,6 +82563,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor1/fore)
+"vym" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall,
+/area/station/medical/storage)
 "vyn" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/sign/poster/official/random/directional/south,
@@ -81833,35 +82669,19 @@
 /turf/open/floor/iron/white/textured_large,
 /area/station/service/chapel/office)
 "vzi" = (
-/obj/item/storage/backpack/duffelbag/med/surgery{
-	pixel_y = 13
-	},
-/obj/item/reagent_containers/medigel/sterilizine{
-	pixel_x = 1
-	},
-/obj/item/reagent_containers/syringe{
-	pixel_x = -7
-	},
-/obj/item/stack/medical/bone_gel{
-	pixel_x = 10
-	},
-/obj/effect/turf_decal/box/white,
-/obj/structure/table/reinforced/rglass,
-/turf/open/floor/iron/dark/textured,
-/area/station/medical/surgery/aft)
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/medical/office)
 "vzt" = (
-/obj/item/storage/box/bodybags,
-/obj/item/storage/box/beakers{
-	pixel_x = 4;
-	pixel_y = 4
+/obj/machinery/suit_storage_unit/cmo,
+/obj/effect/turf_decal/trimline/blue/filled/end{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/machinery/camera/directional/north{
-	c_tag = "Medical - APC"
-	},
-/obj/structure/table/glass,
-/turf/open/floor/iron/white/textured,
-/area/station/medical/medbay/central)
+/turf/open/floor/iron/white,
+/area/station/command/heads_quarters/cmo)
 "vzu" = (
 /obj/effect/landmark/start/psychologist,
 /obj/structure/sign/poster/official/random/directional/south,
@@ -82008,16 +82828,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den)
-"vBk" = (
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/machinery/suit_storage_unit/medical,
-/turf/open/floor/iron/white,
-/area/station/medical/storage)
 "vBm" = (
-/obj/structure/table/optable,
-/obj/machinery/defibrillator_mount/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/medical/surgery/fore)
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/structure/closet/secure_closet/medical3,
+/turf/open/floor/iron/white/textured,
+/area/station/medical/storage)
 "vBA" = (
 /obj/machinery/door/airlock/medical{
 	name = "Safe Habitation B"
@@ -82209,6 +83024,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/button/elevator/directional/south{
+	id = "com_vator"
+	},
+/obj/machinery/lift_indicator/directional/south{
+	linked_elevator_id = "com_vator";
+	pixel_y = -36
+	},
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -82261,6 +83083,13 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor4/port)
+"vFU" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/grille/broken,
+/obj/structure/ladder,
+/turf/open/floor/plating,
+/area/station/hallway/floor3/fore)
 "vFV" = (
 /obj/effect/turf_decal/trimline/blue/end,
 /obj/effect/mapping_helpers/airlock/access/any/command/general,
@@ -82277,13 +83106,12 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor4/fore)
 "vFY" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white/textured,
+/area/station/medical/paramedic)
 "vGi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -82294,7 +83122,7 @@
 /area/station/service/theater)
 "vGj" = (
 /obj/machinery/light/cold/directional/west,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/dark,
 /area/station/medical/psychology)
 "vGk" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -82315,6 +83143,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor4/fore)
+"vGE" = (
+/obj/effect/turf_decal/siding/wideplating,
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/medbay/central)
 "vGO" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/green/half/contrasted{
@@ -82376,12 +83211,17 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor4/aft)
 "vHc" = (
-/obj/item/kirbyplants/photosynthetic,
-/obj/machinery/light/cold/directional/east,
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/machinery/camera/autoname/directional/north,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/obj/structure/chair/sofa/corp/right{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 8
+	},
+/obj/structure/sign/poster/official/random/directional/east,
+/obj/structure/sign/poster/random/directional/north,
+/obj/effect/landmark/start/paramedic,
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/paramedic)
 "vHd" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
@@ -82472,10 +83312,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor4/starboard/aft)
-"vIb" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/iron/white,
-/area/station/medical/storage)
 "vIe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/sign/poster/contraband/random/directional/east,
@@ -82510,6 +83346,16 @@
 /obj/structure/flora/bush/flowers_yw/style_random,
 /turf/open/floor/grass,
 /area/station/hallway/floor1/fore)
+"vIy" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/medbay/aft)
 "vIC" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/purple/opposingcorners,
@@ -82596,6 +83442,13 @@
 /obj/effect/spawner/random/entertainment/arcade,
 /turf/open/floor/eighties,
 /area/station/commons/fitness/recreation/entertainment)
+"vJM" = (
+/obj/effect/turf_decal/trimline/blue/warning{
+	dir = 4
+	},
+/obj/machinery/duct,
+/turf/open/floor/pod/dark,
+/area/station/maintenance/floor2/port)
 "vJS" = (
 /obj/machinery/requests_console/directional/north{
 	department = "Law Office";
@@ -82621,10 +83474,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/pod/light,
 /area/station/maintenance/solars/port/aft)
-"vKt" = (
-/obj/machinery/chem_master,
-/turf/open/floor/pod/light,
-/area/station/maintenance/department/medical)
 "vKv" = (
 /obj/item/stack/ducts/fifty,
 /obj/structure/rack,
@@ -82673,15 +83522,12 @@
 /turf/open/floor/engine,
 /area/station/science/cytology)
 "vLf" = (
-/obj/structure/railing{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/wood/parquet,
-/area/station/command/heads_quarters/cmo)
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "vLj" = (
 /obj/effect/spawner/random/decoration/generic,
 /obj/structure/rack,
@@ -82782,11 +83628,20 @@
 	dir = 8
 	},
 /area/station/maintenance/floor4/port/fore)
+"vNe" = (
+/obj/machinery/camera/autoname/directional/west,
+/turf/open/floor/iron/dark/side,
+/area/station/hallway/floor2/fore)
 "vNj" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/tile/dark/full,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/storage/tech)
+"vNk" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "vNq" = (
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/ai_monitored/command/storage/eva)
@@ -82806,11 +83661,19 @@
 	},
 /area/station/hallway/floor4/aft)
 "vNA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/department/medical)
+/obj/structure/industrial_lift/public,
+/obj/machinery/lift_indicator/directional/east{
+	linked_elevator_id = "com_vator";
+	pixel_x = 38;
+	pixel_y = -7
+	},
+/obj/machinery/elevator_control_panel/directional/east{
+	linked_elevator_id = "com_vator";
+	pixel_x = 24;
+	preset_destination_names = list("3"="Medsci","4"="Service","5"="Command")
+	},
+/turf/open/floor/plating/elevatorshaft,
+/area/station/hallway/floor2/fore)
 "vNF" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -82950,6 +83813,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/cargo/sorting)
+"vPb" = (
+/obj/machinery/duct,
+/obj/machinery/light_switch/directional/south{
+	pixel_x = -6
+	},
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "vPg" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
@@ -83013,14 +83883,6 @@
 /obj/machinery/status_display/ai/directional/west,
 /turf/open/floor/iron,
 /area/station/science/auxlab)
-"vPZ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
 "vQb" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
@@ -83060,7 +83922,11 @@
 /turf/open/floor/iron,
 /area/station/service/chapel)
 "vQz" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "vQB" = (
@@ -83070,14 +83936,13 @@
 /turf/open/floor/wood,
 /area/station/service/kitchen/diner)
 "vQD" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
-/area/station/medical/storage)
+/area/station/medical/office)
 "vQR" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/iron/dark/side{
@@ -83139,6 +84004,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/floor3/aft)
 "vRB" = (
+/obj/effect/landmark/start/psychologist,
 /turf/open/floor/iron/white/small{
 	name = "padded floor"
 	},
@@ -83177,6 +84043,15 @@
 /obj/effect/landmark/navigate_destination/cargo,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
+"vSr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "vSE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/blue/line{
@@ -83314,9 +84189,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/psychology)
+"vUi" = (
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "vUq" = (
-/turf/open/floor/pod/light,
-/area/station/maintenance/department/medical)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/station/hallway/floor2/aft)
 "vUt" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/dark/visible{
 	dir = 4
@@ -83329,6 +84214,11 @@
 /obj/structure/sign/departments/security/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor3/fore)
+"vUw" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/medical/medbay/lobby)
 "vUG" = (
 /obj/structure/easel,
 /obj/item/canvas/twentyfour_twentyfour,
@@ -83519,6 +84409,12 @@
 	},
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/starboard)
+"vWT" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/aft)
 "vWX" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/cup/mortar,
@@ -83839,12 +84735,12 @@
 	},
 /area/station/hallway/secondary/exit/departure_lounge)
 "wbh" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
 	},
-/obj/machinery/light/cold/directional/west,
-/obj/structure/closet/l3closet/virology,
-/obj/structure/sign/departments/psychology/directional/west,
+/obj/structure/sign/departments/psychology/directional/west{
+	name = "Asylum Entrance"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "wbk" = (
@@ -83943,12 +84839,6 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/station/tcommsat/server)
-"wcB" = (
-/obj/structure/mirror/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/sink/directional/west,
-/turf/open/floor/wood/parquet,
-/area/station/command/heads_quarters/cmo)
 "wcC" = (
 /obj/effect/spawner/random/trash/moisture_trap,
 /turf/open/floor/plating,
@@ -84000,6 +84890,12 @@
 	dir = 4
 	},
 /area/station/science/robotics/lab)
+"wcV" = (
+/obj/structure/disposalpipe/junction/flip{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "wcW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -84050,19 +84946,12 @@
 /turf/open/floor/carpet/orange,
 /area/station/service/chapel/funeral)
 "wdp" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/effect/spawner/random/engineering/tracking_beacon,
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/medical/paramedic)
 "wdq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -84105,9 +84994,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
-"wdV" = (
-/turf/open/floor/carpet/royalblue,
-/area/station/medical/break_room)
 "wdZ" = (
 /obj/machinery/conveyor{
 	dir = 6;
@@ -84224,11 +85110,12 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "wfO" = (
-/obj/effect/turf_decal/tile/blue/full,
-/obj/structure/table/glass,
-/obj/item/storage/medkit/emergency,
-/turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/obj/machinery/vending/wardrobe/coroner_wardrobe,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "wfR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -84253,27 +85140,42 @@
 	},
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
-"wge" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 5
-	},
-/turf/open/floor/carpet/royalblue,
-/area/station/command/heads_quarters/cmo)
 "wgk" = (
-/obj/machinery/light/cold/directional/east,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Triage"
 	},
-/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron/dark/textured,
-/area/station/medical/cryo)
+/obj/effect/mapping_helpers/airlock/access/any/medical/general,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/duct,
+/turf/open/floor/iron/white/textured,
+/area/station/medical/office)
 "wgn" = (
 /obj/structure/cable,
 /obj/machinery/light/small/directional/north,
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/dark/smooth_half,
 /area/station/engineering/storage/tech)
+"wgB" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/brigdoor/left/directional/west{
+	name = "Pharmacy Desk";
+	req_access = list("pharmacy")
+	},
+/obj/machinery/door/window/left/directional/east{
+	name = "Pharmacy Desk"
+	},
+/obj/item/paper_bin,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "chem-lock-a";
+	name = "Chemistry Shutters"
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/pharmacy)
 "wgO" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -84313,12 +85215,6 @@
 /obj/machinery/door/window/brigdoor,
 /turf/open/misc/sandy_dirt,
 /area/station/maintenance/floor1/starboard)
-"whr" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/table/reinforced/rglass,
-/obj/item/storage/medkit/surgery,
-/turf/open/floor/iron/dark,
-/area/station/command/heads_quarters/cmo)
 "whF" = (
 /obj/machinery/shower/directional/east,
 /turf/open/floor/catwalk_floor/iron_dark,
@@ -84536,19 +85432,14 @@
 /obj/item/clothing/head/helmet/old,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/floor2/starboard/aft)
-"wjC" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
 "wkm" = (
 /obj/effect/turf_decal/siding/wood,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/table/wood,
+/obj/machinery/fax{
+	fax_name = "Medical";
+	name = "Medical Fax Machine"
+	},
+/obj/structure/sign/poster/contraband/moffuchis_pizza/directional/east,
 /turf/open/floor/wood/parquet,
 /area/station/medical/break_room)
 "wkn" = (
@@ -84599,6 +85490,18 @@
 	},
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit/escape_pod)
+"wkM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/duct,
+/obj/machinery/power/apc/auto_name/directional/south,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/aft)
 "wkP" = (
 /obj/structure/table,
 /obj/item/reagent_containers/condiment/saltshaker{
@@ -84670,6 +85573,7 @@
 /area/station/command/bridge)
 "wlP" = (
 /obj/structure/reagent_dispensers/water_cooler,
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/wood/parquet,
 /area/station/medical/psychology)
 "wlX" = (
@@ -84829,6 +85733,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/floor3/aft)
+"wnm" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/wood/parquet,
+/area/station/command/heads_quarters/cmo)
 "wnI" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical{
@@ -85051,6 +85962,13 @@
 	},
 /turf/open/floor/carpet/green,
 /area/station/service/bar/atrium)
+"wqu" = (
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/structure/cable,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/iron/white,
+/area/station/medical/pharmacy)
 "wqD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -85162,6 +86080,22 @@
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/wood,
 /area/station/service/bar/atrium)
+"wsn" = (
+/obj/effect/mapping_helpers/airlock/access/all/medical/cmo,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/medical{
+	name = "CMO Office"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/command/heads_quarters/cmo)
 "wss" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/pod/light,
@@ -85210,14 +86144,17 @@
 /turf/open/floor/bamboo/tatami/black,
 /area/station/commons/storage/art)
 "wsN" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/junction/flip{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/station/medical/storage)
 "wsS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -85228,6 +86165,13 @@
 /obj/machinery/atmospherics/components/unary/passive_vent,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"wsW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/surgery/aft)
 "wsY" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -85248,9 +86192,13 @@
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "wti" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/wood/parquet,
-/area/station/command/heads_quarters/cmo)
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/duct,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "wtl" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/external,
@@ -85297,6 +86245,12 @@
 /obj/structure/cable,
 /turf/open/floor/carpet/green,
 /area/station/commons/dorms/apartment2)
+"wtw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/turf/open/floor/wood/parquet,
+/area/station/command/heads_quarters/cmo)
 "wtC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -85346,13 +86300,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
-"wur" = (
-/obj/effect/turf_decal/tile/blue/full,
-/obj/structure/table/glass,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high,
-/turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
 "wus" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/pod/light,
@@ -85543,14 +86490,9 @@
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor2/port/fore)
 "wwS" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "wwT" = (
 /obj/effect/turf_decal/trimline/blue/arrow_ccw{
 	dir = 4
@@ -85574,27 +86516,26 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/station/medical/psychology)
-"wwV" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white/side,
-/area/station/medical/medbay/lobby)
 "wwW" = (
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "wxa" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/effect/mapping_helpers/airlock/access/any/medical/general,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/unres{
 	dir = 4
 	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/machinery/duct,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Treatment Center"
 	},
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "wxb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -85698,11 +86639,11 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload_foyer)
 "wyd" = (
-/obj/item/kirbyplants/photosynthetic,
-/obj/machinery/light/cold/directional/west,
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/computer/crew,
+/obj/machinery/light/cold/directional/north,
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/paramedic)
 "wye" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/bananalamp,
@@ -85927,6 +86868,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/red,
 /area/station/service/theater)
+"wAP" = (
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/structure/cable,
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron/white,
+/area/station/medical/pharmacy)
 "wAV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 4
@@ -86012,10 +86959,7 @@
 	},
 /area/station/medical/chemistry)
 "wCX" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/junction{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
@@ -86063,16 +87007,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/entry)
-"wDm" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/blue/arrow_cw{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "wDr" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/dirt,
@@ -86220,7 +87154,10 @@
 /obj/structure/chair/sofa/left{
 	dir = 8
 	},
-/obj/item/toy/plush/beeplushie,
+/obj/item/toy/plush/beeplushie{
+	name = "Bee Haave";
+	desc = "A cute bee toy to calm down hysteric patients."
+	},
 /turf/open/floor/wood,
 /area/station/medical/psychology)
 "wFT" = (
@@ -86414,10 +87351,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/security/medical)
-"wHF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/medical/exam_room)
 "wHP" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
@@ -86518,14 +87451,14 @@
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/rd)
 "wIM" = (
-/obj/effect/turf_decal/tile/yellow/full,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id = "chem-lock-f";
+	name = "Chemistry Shutters"
 	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
+/turf/open/floor/plating,
 /area/station/hallway/floor2/aft)
 "wIN" = (
 /turf/open/openspace,
@@ -86860,11 +87793,6 @@
 /obj/structure/closet/secure_closet/security,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/checkpoint/second)
-"wLT" = (
-/obj/machinery/light/cold/no_nightlight/directional/west,
-/obj/structure/sign/departments/medbay/alt/directional/west,
-/turf/open/floor/iron,
-/area/station/hallway/floor2/aft)
 "wMr" = (
 /obj/machinery/door/airlock{
 	id_tag = "dorms_3_bolts";
@@ -86913,6 +87841,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/hallway/floor2/aft)
+"wMS" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/pharmacy)
 "wMU" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
@@ -87085,18 +88017,25 @@
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor3/port/aft)
 "wPu" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/duct,
-/obj/machinery/button/door/directional/west{
-	id = "surg_a_privacy";
-	name = "Surgery Privacy Shutters";
+/obj/item/storage/medkit/toxin{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/storage/medkit/toxin,
+/obj/item/storage/medkit/toxin{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/item/storage/medkit/regular,
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/machinery/door/window/left/directional/east{
+	name = "First Aid Supplies";
 	req_access = list("medical")
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/surgery/fore)
+/turf/open/floor/iron/white/textured,
+/area/station/medical/storage)
 "wPw" = (
 /obj/structure/chair/comfy,
 /obj/structure/cable,
@@ -87235,23 +88174,26 @@
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
+"wRg" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "cmo_privacy";
+	name = "CMO Privacy Shutters"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/medical/storage)
 "wRn" = (
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
 "wRx" = (
-/obj/structure/bed{
-	dir = 4
-	},
-/obj/item/bedsheet/medical{
-	dir = 4
-	},
-/obj/structure/curtain/cloth,
-/obj/machinery/newscaster/directional/north,
-/obj/effect/landmark/start/medical_doctor,
-/turf/open/floor/wood/parquet,
-/area/station/medical/exam_room)
+/obj/effect/baseturf_helper/reinforced_plating/ceiling,
+/obj/machinery/light_switch/directional/south,
+/turf/open/floor/iron/white,
+/area/station/command/heads_quarters/cmo)
 "wRD" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -87451,9 +88393,6 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/exit/escape_pod)
-"wUA" = (
-/turf/open/floor/iron/dark/textured,
-/area/station/medical/surgery/aft)
 "wUF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -87501,24 +88440,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/command/heads_quarters/rd)
-"wVf" = (
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/effect/mapping_helpers/airlock/access/any/medical/general,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 4
-	},
-/obj/machinery/door/airlock/medical/glass{
-	name = "Treatment Center"
-	},
-/obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
 "wVl" = (
 /obj/effect/turf_decal/siding/wood/corner,
 /turf/open/floor/iron/dark/side,
@@ -87607,11 +88528,8 @@
 /turf/closed/wall,
 /area/station/medical/break_room)
 "wVZ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/carpet,
-/area/station/medical/psychology)
+/turf/closed/wall/r_wall,
+/area/station/hallway/floor2/fore)
 "wWf" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Maintenance Hatch"
@@ -87817,10 +88735,12 @@
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor2/port/fore)
 "wZr" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white/side,
-/area/station/medical/medbay/lobby)
+/obj/machinery/door/airlock/medical{
+	name = "Paramedic Dispatch"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/medical/general,
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/paramedic)
 "wZt" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/effect/turf_decal/stripes/line{
@@ -87942,6 +88862,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/hangover,
+/obj/structure/sign/poster/official/random/directional/west,
 /turf/open/floor/iron/white,
 /area/station/hallway/floor2/fore)
 "xaW" = (
@@ -87998,20 +88919,10 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "xbD" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/blue/corner{
-	dir = 1
-	},
-/obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/camera/autoname/directional/north,
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/cryo)
 "xbF" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/marker_beacon/burgundy,
@@ -88177,7 +89088,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
-/obj/item/radio/intercom/directional/west,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "xdJ" = (
@@ -88316,8 +89230,25 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/red/line,
 /obj/machinery/door/firedoor/border_only,
+/obj/structure/railing,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor3/port/aft)
+"xfS" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/chair/sofa/bench/solo{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/structure/disposalpipe/junction/flip{
+	dir = 1
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "xfT" = (
 /turf/open/floor/plating,
 /area/station/maintenance/floor1/port)
@@ -88410,6 +89341,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/red,
 /area/station/service/theater)
+"xhm" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/medical/office)
 "xhp" = (
 /obj/machinery/computer/security{
 	dir = 1
@@ -88418,14 +89353,10 @@
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
 "xhs" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 4;
-	id = "cmo_privacy";
-	name = "CMO Privacy Shutters"
-	},
-/turf/open/floor/plating,
-/area/station/command/heads_quarters/cmo)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/white/textured,
+/area/station/medical/storage)
 "xht" = (
 /obj/effect/turf_decal/trimline/blue/corner{
 	dir = 1
@@ -88452,12 +89383,12 @@
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/secondary/entry)
 "xhB" = (
-/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/railing{
+	dir = 4
+	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/turf/open/floor/iron/white/textured,
-/area/station/medical/medbay/central)
+/turf/open/floor/wood/parquet,
+/area/station/command/heads_quarters/cmo)
 "xhC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -88558,7 +89489,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron/white,
 /area/station/medical/abandoned)
 "xiO" = (
 /obj/machinery/atmospherics/pipe/smart/simple/pink/visible/layer2{
@@ -88655,15 +89586,10 @@
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor4/starboard/fore)
 "xkn" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/hatch{
-	name = "Maintenance Hatch"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/turf/open/floor/pod/dark,
-/area/station/maintenance/floor2/port)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/light_switch/directional/east,
+/turf/open/floor/iron/white/herringbone,
+/area/station/medical/patients_rooms)
 "xko" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -88697,6 +89623,14 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
+"xky" = (
+/obj/structure/bed{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/structure/sign/poster/official/random/directional/west,
+/turf/open/floor/iron/white/textured,
+/area/station/medical/office)
 "xkC" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 8
@@ -88706,7 +89640,11 @@
 /turf/open/floor/carpet/red,
 /area/station/service/theater)
 "xkF" = (
-/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "xkN" = (
@@ -88770,9 +89708,12 @@
 /turf/open/floor/plating/airless,
 /area/space)
 "xlx" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/duct,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "xlD" = (
@@ -88889,14 +89830,17 @@
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor3/starboard/fore)
 "xny" = (
-/obj/machinery/door/airlock/medical{
-	name = "CMO Quarters"
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/cmo,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/wood/parquet,
-/area/station/command/heads_quarters/cmo)
+/obj/structure/table,
+/obj/structure/sign/poster/official/random/directional/north,
+/obj/machinery/duct,
+/obj/item/stack/medical/suture,
+/obj/item/stack/medical/mesh,
+/obj/item/healthanalyzer,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "xnL" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 8
@@ -89252,15 +90196,6 @@
 /obj/effect/turf_decal/siding/thinplating_new,
 /turf/open/floor/iron/smooth,
 /area/station/cargo/sorting)
-"xtr" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "xtC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -89662,6 +90597,19 @@
 /obj/effect/turf_decal/tile/green/opposingcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"xyu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/aft)
 "xyz" = (
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /turf/open/floor/pod/light,
@@ -89891,22 +90839,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"xBN" = (
-/obj/machinery/newscaster/directional/north,
-/obj/structure/table/optable{
-	desc = "A cold, hard place for your final rest.";
-	name = "Morgue Slab"
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/medical/morgue)
 "xBT" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/dark,
 /area/station/medical/psychology)
 "xBU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -89939,9 +90876,15 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "xCn" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/medical/cryo)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/shower/directional/south,
+/obj/effect/turf_decal/trimline/blue/end,
+/turf/open/floor/noslip{
+	icon_state = "textured_dark"
+	},
+/area/station/medical/office)
 "xCw" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -90307,7 +91250,7 @@
 "xGB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
+/turf/open/floor/iron/white,
 /area/station/medical/abandoned)
 "xGI" = (
 /turf/closed/wall,
@@ -90337,17 +91280,20 @@
 /turf/open/floor/iron/textured,
 /area/station/command/heads_quarters/qm)
 "xGT" = (
-/obj/item/roller,
-/obj/item/roller{
-	pixel_y = 3
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
 	},
-/obj/item/roller{
-	pixel_y = 6
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/structure/table/glass,
-/turf/open/floor/iron/white/textured,
-/area/station/medical/medbay/central)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/command/heads_quarters/cmo)
 "xGU" = (
 /obj/effect/turf_decal/trimline/brown/warning{
 	dir = 4
@@ -90560,6 +91506,16 @@
 /obj/structure/railing/corner,
 /turf/open/space/openspace,
 /area/space)
+"xKv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/aft)
 "xKy" = (
 /obj/machinery/modular_computer/console/preset/id{
 	dir = 8
@@ -90607,17 +91563,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
-"xLp" = (
-/obj/machinery/door/airlock/medical{
-	name = "Morgue"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/any/medical/morgue,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white,
-/area/station/medical/morgue)
 "xLs" = (
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/floor2/fore)
@@ -90728,9 +91673,15 @@
 	},
 /area/station/engineering/atmos/office)
 "xNm" = (
-/obj/machinery/atmospherics/components/unary/cryo_cell,
-/turf/open/floor/iron/dark/textured,
-/area/station/medical/cryo)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "xNx" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
@@ -91415,6 +92366,10 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/wood/large,
 /area/station/service/library/artgallery)
+"xXV" = (
+/obj/structure/lattice/catwalk,
+/turf/open/floor/catwalk_floor,
+/area/station/maintenance/floor3/port/aft)
 "xXY" = (
 /obj/machinery/newscaster/directional/west,
 /obj/structure/chair{
@@ -91590,6 +92545,19 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/medical/break_room)
+"xZG" = (
+/obj/machinery/door/airlock/medical{
+	name = "Operating Room B"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/medical/surgery,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/medical/surgery/aft)
 "xZL" = (
 /turf/closed/wall,
 /area/station/security/brig)
@@ -91748,6 +92716,10 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor3/fore)
+"ybR" = (
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/turf/open/floor/iron/white,
+/area/station/medical/pharmacy)
 "ybY" = (
 /obj/structure/chair/comfy/brown,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
@@ -91785,22 +92757,9 @@
 	},
 /area/station/ai_monitored/command/storage/eva)
 "ycd" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/white/textured,
+/area/station/medical/paramedic)
 "ycg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /turf/open/floor/circuit/telecomms,
@@ -91954,9 +92913,17 @@
 /turf/open/floor/plating,
 /area/station/security/prison/garden)
 "yeZ" = (
-/obj/effect/landmark/start/coroner,
-/turf/open/floor/iron/dark/textured,
-/area/station/medical/morgue)
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "yfh" = (
 /obj/structure/frame/machine,
 /obj/item/stack/cable_coil/cut,
@@ -92161,13 +93128,21 @@
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port/fore)
 "yit" = (
-/obj/machinery/airalarm/directional/west,
-/obj/machinery/vending/wardrobe/coroner_wardrobe,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/railing/corner{
 	dir = 8
 	},
-/turf/open/floor/iron/dark/textured,
-/area/station/medical/morgue)
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "yiw" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -92224,6 +93199,18 @@
 /obj/item/pen,
 /turf/open/floor/carpet,
 /area/station/commons/vacant_room/office)
+"yjy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/storage)
 "yjG" = (
 /obj/machinery/rnd/production/circuit_imprinter/department/science,
 /obj/effect/turf_decal/bot,
@@ -92267,6 +93254,15 @@
 	},
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor1/port/aft)
+"yjZ" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/structure/bed/roller,
+/obj/machinery/iv_drip,
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/office)
 "ykb" = (
 /turf/open/floor/wood,
 /area/station/commons/dorms/apartment1)
@@ -92276,10 +93272,11 @@
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor4/port/fore)
 "ykk" = (
-/obj/effect/turf_decal/siding/white,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
 /obj/machinery/light/cold/directional/north,
-/obj/machinery/computer/crew,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "yko" = (
 /obj/structure/cable,
@@ -120318,7 +121315,7 @@ xgH
 wVn
 xgH
 xgH
-qUQ
+xgH
 xgH
 uZk
 uZk
@@ -121586,8 +122583,8 @@ lPs
 pRG
 vOK
 xgH
-xfT
-xSl
+pEN
+tuY
 dyS
 dyS
 dyS
@@ -185846,16 +186843,16 @@ lQI
 lQI
 lQI
 lQI
-hLz
-hLz
-hLz
-hLz
-hLz
-hLz
-hLz
-hLz
-hLz
-hLz
+hOA
+hOA
+hOA
+hOA
+hOA
+hOA
+hOA
+hOA
+hOA
+hOA
 hLz
 hLz
 hLz
@@ -186096,14 +187093,14 @@ jzq
 eoc
 qAv
 oWY
-cmG
+cVs
 bSV
-hLz
-hLz
-hLz
-hLz
-hLz
-hLz
+hOA
+hOA
+hOA
+hOA
+hOA
+hOA
 cJj
 rfC
 dnB
@@ -186112,7 +187109,7 @@ oys
 rbg
 ozt
 ozt
-hLz
+hOA
 uXA
 uXA
 uXA
@@ -186352,8 +187349,8 @@ jvv
 fNT
 fNT
 fNT
-fNT
-cmG
+wVZ
+cVs
 tyi
 dCx
 mWd
@@ -186369,7 +187366,7 @@ xBT
 mtg
 ozt
 ozt
-hLz
+hOA
 uXA
 hLz
 ceH
@@ -186605,12 +187602,12 @@ dpL
 lCh
 rtv
 lES
-wKr
+jvv
 ueN
 bKz
 kJO
 lGA
-cmG
+iaG
 tyi
 tyi
 xwM
@@ -186626,7 +187623,7 @@ wVY
 wVY
 wVY
 wVY
-hLz
+hOA
 uXA
 tVB
 iiQ
@@ -186864,10 +187861,10 @@ xJs
 kOj
 aYA
 fNT
-dKI
+fNT
 myz
-vgy
-cmG
+wVZ
+jTA
 hNK
 qBz
 bty
@@ -187121,10 +188118,10 @@ fqo
 aSR
 oGL
 fqo
-dKI
-myz
-vgy
-cmG
+fNT
+qMe
+wVZ
+hLw
 qii
 kXi
 orQ
@@ -187140,7 +188137,7 @@ mbv
 xQo
 uCV
 gNm
-aal
+lcv
 aal
 aal
 kpX
@@ -187378,11 +188375,11 @@ kbl
 lES
 vEK
 fNT
-dKI
-dKI
-vNA
-cmG
-oCl
+fNT
+fNT
+wVZ
+wVZ
+wVZ
 wVZ
 rEg
 ckQ
@@ -187397,7 +188394,7 @@ bqY
 xQo
 kor
 rQX
-aal
+lcv
 hCh
 uAe
 adq
@@ -187634,13 +188631,13 @@ idn
 shi
 lES
 nWz
-xLs
+vNe
 uUA
-dKI
-anQ
-cmG
+eNn
 nuG
-dst
+nuG
+nuG
+wVZ
 cmG
 cmG
 qFC
@@ -187654,7 +188651,7 @@ hdd
 hWV
 kpR
 bbg
-aal
+lcv
 aal
 ydS
 adq
@@ -187891,14 +188888,14 @@ ygC
 ygC
 loK
 jQJ
-kQw
+lEV
 bVd
-dKI
-fcc
-cmG
-cmG
-cmG
-cmG
+lEV
+nuG
+kXE
+nuG
+wVZ
+tjk
 jWt
 qlX
 gNT
@@ -187906,12 +188903,12 @@ xdB
 sKY
 fLv
 vQz
-xZB
+iGY
 mvJ
-xQo
-kpR
+dxf
+faY
 kOs
-aal
+lcv
 cKs
 cMh
 pzx
@@ -188149,26 +189146,26 @@ shi
 siE
 nWz
 fQS
-oPD
-dKI
+uUA
+rtv
+nuG
 vNA
-vNA
-kxV
-kxV
+nuG
+wVZ
 dKI
 fjm
-xkF
+vSr
 juM
 xkF
 jWV
 wCX
 trn
-iGY
+xZB
 usG
 wkm
 ktL
 tQu
-aal
+lcv
 aal
 aal
 lTN
@@ -188406,26 +189403,26 @@ nYB
 siE
 gEa
 fNT
-dKI
-dKI
-krA
-vNA
-dKI
-dKI
-dKI
-nrm
-nrm
-nrm
-nrm
-nrm
+fNT
+dye
+fNT
+fNT
+fNT
+wVZ
+rID
+wPX
+kZA
+rXa
 sCs
-liq
-xZB
-tca
-njW
-wdV
+wsn
+sCs
+rXa
 ajq
-aal
+ajq
+ajq
+ajq
+ajq
+lcv
 vyA
 nXb
 lRl
@@ -188663,26 +189660,26 @@ elB
 aTg
 khx
 elB
-dKI
-vKt
+jQx
+gAz
 vUq
-vNA
-dKI
-gjA
+gAz
+aft
+otp
 jqH
-oQF
-qnb
-mYN
+wyE
+kZA
+ifp
 iQL
 oMF
-sCs
-iZe
-wVY
+wnm
+tiN
+nPR
 djo
-cUm
+rXa
 ttZ
 aSa
-aal
+lcv
 iiA
 iiA
 ugP
@@ -188919,27 +189916,27 @@ qun
 wrb
 qGi
 gLJ
-kKr
-kKr
-kKr
-kKr
+fPy
+fPy
+fPy
+fPy
 jAZ
-kKr
-sbZ
+fPy
+otp
 wti
-wge
-eHv
-mYN
+wyE
+kZA
+ifp
 xhB
 oUS
 mWi
 rue
+bDh
+mMN
+sAV
+wtw
 gXY
-gXY
-gXY
-gXY
-gXY
-aal
+lcv
 iiA
 iiA
 yeB
@@ -189175,28 +190172,28 @@ vbP
 qun
 jyD
 tQq
-aWc
+sGu
 hDE
 eor
 nhJ
 vYl
-hbT
+ybR
+ayh
 kKr
-fxp
 mAb
-wcB
+wyE
 gFE
-mYN
+rXa
 vzt
 xGT
-sCs
 nMO
-gXY
+nMO
+ebC
 wRx
-reA
+rXa
 qpj
 dWR
-aal
+lcv
 qqY
 lxG
 kcy
@@ -189432,28 +190429,28 @@ nQS
 qun
 tKl
 tQq
-aWc
+sGu
 hDE
 qRy
-nPG
+eVB
 sYb
 cLv
+ybR
 kKr
-mYN
 xny
+wyE
+bXd
+rXa
+ifC
 mYN
-mYN
-mYN
-mYN
-mYN
-nLI
-dRc
+wRD
+vPN
 nUC
-qmB
-eAT
+nmZ
+rXa
 kuX
 qmB
-aal
+lcv
 ybG
 vph
 ybG
@@ -189689,28 +190686,28 @@ nQS
 eHc
 cCc
 tQq
-aWc
+sGu
 hDE
 ilg
 gmj
 unV
-hLJ
+noh
+pud
 kKr
-aUz
 mAb
 eMA
-tiN
-eEl
-rjf
+kZA
+rXa
+igX
 fof
-sCs
-wDm
+aDp
+xug
 cil
 cTP
-ujG
-bGT
 rXa
-aal
+rXa
+rXa
+lcv
 ybG
 jTH
 eVQ
@@ -189946,28 +190943,28 @@ doJ
 eHc
 cCc
 tQq
-aWc
+sGu
 hDE
 rSf
 tld
 xuD
-jNh
+noh
+mHU
 kKr
-kza
 vLf
-hSC
-jmZ
-sOd
-jCc
-fof
-kxZ
+wyE
+kZA
+rXa
+hxv
+deP
+xKy
 bVP
-nUC
+uwV
 gnb
-nMm
-wHF
+rXa
 glg
-aal
+glg
+lcv
 gPJ
 gPJ
 gPJ
@@ -190204,7 +191201,7 @@ eHc
 cCc
 tQq
 oUy
-kKr
+fPy
 kKr
 jSw
 kKr
@@ -190212,19 +191209,19 @@ fbD
 kKr
 kKr
 hmk
+mZx
 tMo
-tMo
-ofI
-rSx
-vix
-nBt
-uAI
-gXY
-gXY
-gXY
-gXY
-gXY
-aal
+oKx
+oKx
+wRg
+wRg
+wRg
+wRg
+oKx
+vym
+adh
+obl
+lcv
 jqJ
 kFd
 jqJ
@@ -190463,26 +191460,26 @@ tQq
 sGu
 wIM
 hQl
-ohL
 ihp
+wAP
 noh
 obM
 kKr
 dXt
-wRD
-vPN
-okN
+wyE
+qKw
+nUa
 cBa
-dYv
+fbu
 cXO
-mWW
-jpB
+vBm
+vBm
 wPu
 jZe
-bYn
-rBK
-aal
-jqJ
+fbu
+fbu
+lcv
+hAg
 lrA
 jqJ
 biS
@@ -190719,29 +191716,29 @@ hBG
 tQq
 sGu
 wIM
-bLW
 cbu
+xsi
 xsi
 epO
 roJ
 kKr
-igX
-aDp
-xug
+sPx
+wPX
+kZA
 pmk
 oyt
-fof
+pmj
 dJj
 jmr
-tQN
-ciC
-uQN
-wmQ
-wba
-aal
+naf
+mjA
+mjA
+lcr
+cpV
+lcv
 jqJ
 jqJ
-jqJ
+hAg
 jHr
 aal
 aal
@@ -190976,26 +191973,26 @@ ubi
 tQq
 sGu
 wIM
-nsE
 ihj
+aog
 aog
 sSO
 aIe
 kKr
-hxv
-xKy
-whr
+tOE
+wyE
+kZA
+pmk
 svp
-svp
-fof
-sCs
+qAn
+pOo
 iYX
-fdW
-lqx
+aWl
+rhI
 rhI
 nzz
 pvM
-aal
+lcv
 gzw
 gzw
 gzw
@@ -191233,26 +192230,26 @@ xYM
 tQq
 sGu
 wIM
-hQl
 lqU
+wqu
 iXb
 htD
 qUv
 kKr
+mAb
+wyE
+kZA
+pmk
 xhs
-xhs
-xhs
-xhs
-xhs
-mYN
-muN
-iYX
-fdW
-lqx
+cKu
+mjA
+mjA
+aIw
+fVP
 ufA
 cBF
 vBm
-aal
+lcv
 gUR
 wxd
 aNV
@@ -191488,8 +192485,8 @@ bMb
 bFZ
 hgp
 tQq
-cPk
-kKr
+oUy
+fPy
 kKr
 jSw
 kKr
@@ -191497,19 +192494,19 @@ hKK
 kKr
 kKr
 uon
-eFU
-eFU
-cMi
-eFU
+vUi
+bVb
+ohF
+iTW
 eFU
 wsN
-iYX
-fdW
-quE
+gQh
+yjy
+tWV
 tWV
 nTx
 lAE
-aal
+lcv
 pMR
 vSE
 gty
@@ -191746,27 +192743,27 @@ roa
 xYM
 tQq
 aWc
-hDE
+fKr
 gLg
-tld
-xuD
+wMS
+pWe
 nxN
 kKr
 qEQ
 dpu
-qcb
+wyE
 cuZ
-ldw
+nUa
 npc
 jJf
-sCs
+mcC
 jQj
-tQN
-tQN
-tQN
-tQN
-tQN
-aal
+ayK
+fbu
+aaq
+fbu
+eyb
+lcv
 eeL
 ybG
 ybG
@@ -192003,27 +193000,27 @@ wTS
 xYM
 tQq
 aWc
-hDE
+fKr
 ilg
-gmj
+nWT
 unV
 fTN
 myF
-wPX
-neu
-dCp
+vGE
+dpu
+eMA
 xlx
-eKJ
-xlx
-dCp
-sCs
-kzO
-jrP
-uZz
-jXv
-lag
+nrm
 pcB
-aal
+pcB
+pcB
+pcB
+pcB
+uZz
+tNL
+pcB
+pcB
+lcv
 sEd
 ybG
 mDI
@@ -192260,27 +193257,27 @@ xni
 xYM
 tQq
 aWc
-hDE
-qRy
+fKr
+kAk
 nPG
-sYb
+olS
 vib
-kKr
-wyE
+baw
+jxn
 kEl
-ylR
+wcV
 sYk
 sZT
-rLi
-ylR
+pcB
+imU
 pIz
-jmr
-ivL
-xbN
-pOi
-rxz
-hdS
-aal
+tKE
+mCj
+iIh
+mXq
+bMx
+xky
+lcv
 kri
 ybG
 hQO
@@ -192517,27 +193514,27 @@ vsx
 bYg
 tQq
 aWc
-hDE
+fKr
 fuY
 nRQ
-olS
+adt
 lXz
-kKr
-wyE
-kEl
-xCn
+eop
+vGE
+ayw
+dFI
 xNm
 ofY
-xcY
+pcB
 xCn
-sCs
-iYX
-cuL
-aVX
+lcP
+iGC
+pps
+eFG
 vzi
-wUA
 bMx
-aal
+bMx
+lcv
 aal
 kJD
 aal
@@ -192774,27 +193771,27 @@ vsx
 jEk
 tQq
 udr
+fPy
+sSL
+wgB
+iul
 kKr
 kKr
-kKr
-kKr
-rUP
-kKr
-wyE
-kEl
-xCn
-xNm
-ofY
-igS
+nrm
+aWb
+hWz
+aWb
+nrm
+pcB
 qmh
-sCs
-iYX
-cuL
-aVX
+uCO
+okQ
+okQ
+gAE
 sZx
-agv
+bMx
 uST
-aal
+lcv
 aSs
 nca
 vTS
@@ -193030,28 +194027,28 @@ kBc
 vsx
 xYM
 tQq
-aWc
-nrm
+joc
+ppy
 lpb
-kEl
-xtr
+njp
+qob
 oUZ
-npm
-sCs
-kEl
-xCn
+aHk
+hkU
+lEm
+ulf
 rDu
-ofY
-lPL
-xCn
-sCs
+adm
+pcB
+qgn
+aHD
 rQo
-cuL
+gBE
 adB
-sYd
-jyd
-rof
-aal
+sZx
+bMx
+bMx
+lcv
 uAe
 nca
 vae
@@ -193288,27 +194285,27 @@ vsx
 xYM
 tQq
 itp
-nrm
-mgh
+hvG
+lLP
 lgH
 ipA
 cgt
 oSC
 lLP
-pVl
-xCn
+rsq
+xfS
 imi
 tiG
 wgk
-xCn
-sCs
-iYX
-ivL
-ivL
-ivL
-ivL
-ivL
-aal
+nZo
+sBj
+gjN
+fmB
+adB
+sZx
+bMx
+rjt
+lcv
 lph
 nca
 pYg
@@ -193545,31 +194542,31 @@ bSX
 ybm
 tQq
 oyT
-aHk
-aHk
-hhR
-aHk
-vrA
-vrA
-vrA
-vrA
-vrA
-vrA
-vrA
-vrA
-vrA
+pzX
+iFt
+mve
+uwU
+iCb
+vUw
+jIs
+kiF
+jTW
+jpL
+hBe
+xhm
+upX
 qMT
-tiT
-nUa
+pps
+pps
 jKf
 jZF
-kva
-kWz
-nUa
-nUa
-nUa
-kJD
-aal
+pcB
+pcB
+lcv
+lcv
+lcv
+lcv
+lcv
 aal
 ucA
 ucA
@@ -193801,32 +194798,32 @@ sKm
 sKm
 xYM
 tQq
-aWc
-aHk
-ibC
-mve
+hsL
+hvG
+lLP
+cQe
 qLu
-vrA
+tPw
 rKy
 pUv
 yit
 bNQ
 sYS
-omk
-omk
-vrA
+uJu
+kgu
+fcA
 kxZ
-iYX
 qqr
-jOB
+qqr
 vQD
-mjA
-mjA
-lcr
+vQD
+mGg
+jpB
+kQr
 lqz
 lDM
-ybG
-aal
+rBK
+lcv
 aal
 ucA
 ucA
@@ -194058,32 +195055,32 @@ cwb
 ttb
 wQu
 tQq
-aWc
-cNd
+joc
+ppy
 ykk
-mve
+hls
 ora
-vrA
-xBN
+eew
+aHk
 beT
 yeZ
-pHY
-aZs
-agW
-aKF
-teP
-cXO
-iYX
-qqr
+puH
+qYH
+mEd
+pcB
+nsD
+yjZ
+nsD
+oGw
 nhI
 bPo
 kxu
-kYB
-vIb
-lqJ
-nUa
-ybG
-aal
+tQN
+ciC
+uQN
+wmQ
+wba
+lcv
 aal
 ucA
 ucA
@@ -194316,31 +195313,31 @@ hUA
 xYM
 tQq
 cgz
-aHk
+ppy
 lnq
 ffM
 sqt
-ntH
-rRH
-eYT
+aHk
+wdd
+wdd
 iPE
-ktT
+slP
 wxa
-gyU
-svm
-xLp
-nBt
-jQj
-nyx
+wdd
+wdd
+wdd
+wdd
 jVs
-bPo
+jVs
+jVs
+vIy
 noN
-laq
-vIb
+fdW
+lqx
 lrX
-nUa
-ybG
-aal
+ulI
+dPu
+lcv
 aal
 ucA
 ucA
@@ -194572,32 +195569,32 @@ kAm
 hUA
 xYM
 tQq
-aWc
-aHk
-aHk
+sCJ
+sJT
+cme
 hWT
 ccI
-vrA
-vrA
-vce
-oXb
-xBq
+dgR
+oDr
+tbQ
+cQh
+vNV
 tlT
-sRg
-fJU
-vrA
-rja
+hdP
+nrE
+vnQ
+wdd
 sHX
-ohF
+kMd
 jVQ
 kmT
 kyq
-laO
-ldG
+fdW
+lqx
 iqj
-lDM
+qfo
 aYT
-aal
+lcv
 aal
 ucA
 ucA
@@ -194829,32 +195826,32 @@ uae
 hUA
 xYM
 tQq
-lxV
-aHk
+aWc
+sJT
 wyd
-jIs
-uwU
-hBe
-vrA
-vrA
-vrA
-vrA
-vrA
-vrA
-vrA
-vrA
-utM
-jmr
-nUa
+nIF
+eDn
+dgR
+tOW
+rwv
+pzb
+jyk
+vNk
+pGM
+fDL
+coZ
+wdd
+bnd
+xcY
 qUE
 vhf
-lzp
-vBk
-lkL
+kyq
+fdW
+quE
 ngg
-nUa
-ybG
-aal
+fpB
+osy
+lcv
 aal
 ucA
 ucA
@@ -195086,32 +196083,32 @@ pRD
 ttb
 iTw
 tQq
-aje
-wwV
-qob
+tFE
+sJT
+sIk
 uur
-uwU
-hBe
-iJK
-uKm
+bdF
+dgR
+mtj
+kRM
 ryV
-aHk
-slQ
+dco
+nVp
 kMl
-lXO
-nrm
-sCs
+aaU
+gzo
+wdd
 kkF
-nUa
-nUa
-nUa
-nUa
-nUa
-nUa
-nUa
-nUa
-ybG
-aal
+axh
+qUE
+kmT
+wkM
+ivL
+ivL
+ivL
+ivL
+ivL
+lcv
 aal
 ucA
 ucA
@@ -195343,32 +196340,32 @@ sKm
 sKm
 jEk
 tQq
-qBQ
-qpr
-rwV
+aje
+sJT
+dgR
 vFY
 ycd
 dkg
-aZu
+iPc
 aZu
 cgd
 btv
 bfM
-uQk
-uQk
+oaP
+pDF
 uQk
 inQ
 qvR
 srH
 neu
 beu
-tJC
+kyq
+xZG
 pVl
-pVl
-ftr
-ybG
-ybG
-aal
+jXv
+lag
+hCW
+lcv
 aal
 ucA
 ucA
@@ -195600,32 +196597,32 @@ tlA
 ttb
 xYM
 tQq
-aWc
-aWU
+qlE
+sJT
 ucd
 qme
 wdp
-nnw
-atp
+dgR
+xqZ
 ohj
-gtR
-uVl
-mgF
+kUf
+szp
+dYM
 cZu
-oNR
-oXg
-ltj
+hzF
+mtI
+wdd
 xbD
 cQN
-sKY
-pRQ
+qUE
+kmT
 kGh
-fHo
-vwv
-aal
-fUT
-nPo
-aal
+ivL
+xbN
+pOi
+rxz
+hdS
+lcv
 aal
 ucA
 ucA
@@ -195859,30 +196856,30 @@ xYM
 tQq
 pic
 wZr
-puH
+qal
 bBj
 hTs
-hBe
-pCo
+iFi
+qPu
 aHG
-pCo
-aHk
+vOo
+xwZ
+dWZ
+aRz
+fEj
+ilI
 wdd
-wdd
-wdd
-slP
-tkU
-wVf
-slP
-wdd
-aal
-aal
-aal
-aal
-aal
+bnd
+xcY
+qUE
+gcn
+kyq
+cuL
+aVX
+hcP
 fGI
-aal
-aal
+oUX
+lcv
 aal
 ucA
 ucA
@@ -196115,32 +197112,32 @@ ttb
 sLI
 tQq
 lxV
-aHk
+sJT
 vHc
-jIs
-uwU
-hBe
-rgS
+npY
+mpu
+dgR
+qsj
 fwo
 ffY
-aHk
-aIK
-aOd
-vNV
+nLq
+bnC
+dXy
+laG
 bxu
-wjC
+wdd
 msw
 uAT
 kkj
+dYm
+kyq
+cuL
+aVX
+wsW
+aOs
+uFd
+lcv
 aal
-kvm
-ybG
-fUz
-ybG
-ybG
-ybG
-xhf
-xhf
 ucA
 ucA
 ucA
@@ -196372,31 +197369,31 @@ ttb
 uUF
 tQq
 tWv
-aHk
-aHk
-ecx
-sSU
 sJT
-aHk
-cNd
-aHk
-aHk
-tOW
-rwv
-vmj
-bxQ
-pil
-rsH
-fDL
-coZ
-aal
-ybG
-eVU
-eVU
+sJT
+sJT
+sJT
+sJT
+gib
+gib
+gib
+gib
+wdd
+wdd
+wdd
+wdd
+wdd
+ylR
+ylR
+ylR
+vWT
+xyu
+cuL
+eTx
+sGn
 pqm
-pqm
-ybG
-aal
+cpj
+lcv
 aal
 ucA
 ucA
@@ -196630,30 +197627,30 @@ sUy
 cfs
 fzy
 rES
-wLT
 kzK
+xzA
 kzK
 kzK
 fou
 eAV
 hrw
-ttb
-mtj
-kRM
+otp
+gHO
+mmc
 wfO
 ovI
-nVp
-mfy
-aaU
-jGO
-aal
-ybG
-eVU
-hAg
-hAg
-pqm
-ybG
-aal
+dYw
+omk
+omk
+vrA
+imW
+jZD
+ikl
+ikl
+ikl
+ikl
+ikl
+lcv
 aal
 ucA
 ucA
@@ -196894,23 +197891,23 @@ nhA
 dQH
 jdx
 rJd
-ttb
+otp
 ozj
 tog
 djj
 kCe
-fak
-wur
-vPZ
-rPq
-aal
-ybG
+aZs
+agW
+aKF
+vrA
+oLV
+aQo
+ikl
+hRL
+dcd
 eVU
-hAg
-hAg
-eVU
-ybG
-aal
+grK
+lcv
 aal
 ucA
 ucA
@@ -197151,23 +198148,23 @@ kzK
 jSW
 nrX
 mkE
-ttb
-xqZ
+mcH
+iqJ
 wwS
-kUf
-szp
-dYM
+gLc
+sgd
+rfS
 jwH
-hzF
-mtI
-aal
-ybG
-eVU
-pqm
-eVU
+lVd
+ivM
+cDw
+irr
+fqY
+swl
+eGs
 lYl
-ybG
-aal
+swl
+lcv
 aal
 ucA
 ucA
@@ -197408,24 +198405,24 @@ jZS
 hbj
 cle
 bWz
-ttb
-qPu
-csN
-vOo
-xwZ
-dWZ
-aRz
-fEj
-ilI
+otp
+pxe
+pFl
+hpG
+gKT
+qYW
+pFl
+vPb
+vrA
+kfN
+nAD
+lXi
+cPr
+iRF
+eSK
+pqq
+lcv
 aal
-ybG
-ybG
-ybG
-ybG
-ybG
-ybG
-xhf
-xhf
 ucA
 ucA
 ucA
@@ -197665,23 +198662,23 @@ muB
 ttb
 aal
 aal
-aal
-qsj
-oZA
+lcv
+hYS
+eDW
 rip
 gaG
-bnC
-dXy
+eDW
+eDW
 mGW
-tgj
-aal
-aal
-aal
+vrA
+uXd
+xKv
+fqY
 xkn
-aal
-aal
-aal
-aal
+pjA
+jFV
+lnQ
+lcv
 aal
 ucA
 ucA
@@ -197922,23 +198919,23 @@ hoj
 lsQ
 aal
 xJT
-aal
-aal
+lcv
+vce
 uNB
-aal
-aal
-aal
-aal
-aal
-aal
-aal
-oVH
-aal
-ybG
-mbi
-ayo
-bwk
-aal
+oXb
+xBq
+gfL
+sRg
+fJU
+vrA
+riS
+lcv
+lcv
+lcv
+lcv
+lcv
+lcv
+lcv
 aal
 ucA
 ucA
@@ -198179,21 +199176,21 @@ ldI
 cqh
 vff
 ybG
-ybG
-fRp
+lcv
+lcv
+lcv
+lcv
+lcv
+lcv
+lcv
+lcv
+lcv
 lDY
-ybG
-ybG
-sTy
-iHc
-dru
-aal
-oVH
-oVH
-aal
+hWv
+ekb
 uxP
 mbi
-uAe
+dtC
 ocX
 aal
 aal
@@ -198435,19 +199432,19 @@ wGg
 jZS
 sFQ
 aal
-nYX
-lDY
-lDY
-lDY
-dQX
+ybG
+ddS
 ybG
 ybG
 ybG
+ybG
+ybG
+ddS
 nnf
-aal
-aal
-aal
-aal
+tXY
+lDY
+cZo
+vJM
 sSQ
 rTL
 aal
@@ -198964,8 +199961,8 @@ rlw
 fMf
 cUN
 pnc
-lfy
-lfy
+kFd
+lrA
 aal
 aal
 ucA
@@ -253173,9 +254170,9 @@ riD
 sNq
 mOT
 vma
-jww
-jww
-jww
+oZx
+oZx
+oZx
 eDe
 ufs
 ufs
@@ -253430,9 +254427,9 @@ gGZ
 fnf
 elY
 fnf
-jww
-sgi
-jww
+oZx
+oZx
+oZx
 eDe
 ufs
 ufs
@@ -253445,7 +254442,7 @@ rtB
 uZc
 pCH
 bQK
-dYf
+efm
 tGn
 aoM
 aoM
@@ -253687,9 +254684,9 @@ riD
 fQI
 mOT
 fjo
-jww
-kVd
-jww
+oZx
+oZx
+oZx
 eDe
 xGx
 diU
@@ -253702,7 +254699,7 @@ tCU
 dTk
 rfx
 oZp
-awo
+oLH
 tGn
 tGn
 tGn
@@ -253952,7 +254949,7 @@ uZc
 mxP
 wEE
 xGB
-rtB
+tzv
 uZc
 uZc
 sAz
@@ -254203,13 +255200,13 @@ xLG
 pbt
 nZh
 pbt
-nZh
+vFU
 nZh
 uZc
 vAg
 uZc
 kiS
-rtB
+tzv
 uZc
 oua
 dYf
@@ -254466,12 +255463,12 @@ iuo
 iuo
 iuo
 icF
-rtB
+tzv
 uZc
 pjW
 awo
 tzv
-awo
+oLH
 eSa
 tGn
 tGn
@@ -254731,7 +255728,7 @@ mbQ
 lvs
 uZc
 tGn
-qCv
+ocf
 jQK
 mex
 mex
@@ -254981,14 +255978,14 @@ ncl
 iuo
 cQY
 nnc
-awo
+oLH
 awo
 awo
 tzv
-ufs
+oLH
 xiL
 tGn
-aoM
+gtj
 cmr
 cmr
 cmr
@@ -256013,7 +257010,7 @@ uZc
 qsL
 awo
 tzv
-dYf
+efm
 gZm
 tGn
 hnZ
@@ -263472,8 +264469,8 @@ hBp
 pOn
 lXM
 nne
-hcT
-hcT
+lDn
+hBP
 piR
 piR
 ucA
@@ -263730,7 +264727,7 @@ rtc
 pOn
 xfJ
 hcT
-hcT
+xXV
 piR
 piR
 ucA
@@ -264501,7 +265498,7 @@ fHE
 piR
 mom
 hcT
-hcT
+hUL
 piR
 piR
 ucA

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -1566,11 +1566,11 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/weather/snow,
-/mob/living/simple_animal/hostile/retaliate/goat{
-	name = "Pete"
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
+	},
+/mob/living/simple_animal/hostile/retaliate/goat{
+	name = "Pete"
 	},
 /turf/open/floor/iron/kitchen_coldroom,
 /area/station/service/kitchen/coldroom)
@@ -1847,8 +1847,8 @@
 /area/station/asteroid)
 "afh" = (
 /obj/structure/cable,
-/mob/living/carbon/human/species/monkey/punpun,
 /obj/machinery/holopad,
+/mob/living/carbon/human/species/monkey/punpun,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "afi" = (
@@ -2121,7 +2121,7 @@
 /area/station/asteroid)
 "afW" = (
 /obj/effect/spawner/random{
-	loot = list(/obj/effect/decal/cleanable/oil/slippery=10,/obj/effect/decal/cleanable/oil=90);
+	loot = list(/obj/effect/decal/cleanable/oil/slippery = 10, /obj/effect/decal/cleanable/oil = 90);
 	name = "funny slipper :)"
 	},
 /turf/open/floor/noslip/tram_plate,
@@ -2804,7 +2804,7 @@
 	},
 /obj/item/reagent_containers/cup/bottle{
 	desc = "A small bottle of Barber's Aid.";
-	list_reagents = list(/datum/reagent/barbers_aid=30);
+	list_reagents = list(/datum/reagent/barbers_aid = 30);
 	name = "Barber's Aid bottle";
 	pixel_x = -2;
 	pixel_y = 10
@@ -7432,7 +7432,7 @@
 /area/station/security/courtroom)
 "beq" = (
 /obj/machinery/computer/atmos_control/oxygen_tank{
-	atmos_chambers = list("o2ordance"="Oxygen Supply")
+	atmos_chambers = list("o2ordance" = "Oxygen Supply")
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/airalarm/directional/north,
@@ -8350,11 +8350,11 @@
 	codes_txt = "delivery;dir=2";
 	location = "QM #2"
 	},
+/obj/effect/turf_decal/tile/brown/fourcorners,
 /mob/living/simple_animal/bot/mulebot{
 	home_destination = "QM #2";
 	suffix = "#2"
 	},
-/obj/effect/turf_decal/tile/brown/fourcorners,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "bxC" = (
@@ -10574,7 +10574,7 @@
 /obj/machinery/elevator_control_panel{
 	linked_elevator_id = "tram_xeno_lift";
 	pixel_y = 2;
-	preset_destination_names = list("2"="Lower Deck","3"="Upper Deck");
+	preset_destination_names = list("2" = "Lower Deck", "3" = "Upper Deck");
 	layer = 3.1
 	},
 /turf/closed/wall/r_wall,
@@ -10656,7 +10656,7 @@
 	desc = "A small control panel used to move the kitchen dumbwaiter up and down.";
 	linked_elevator_id = "dumbwaiter_lift";
 	name = "Dumbwaiter control Panel";
-	preset_destination_names = list("2"="Hydroponics","3"="Kitchen")
+	preset_destination_names = list("2" = "Hydroponics", "3" = "Kitchen")
 	},
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal/bin,
@@ -12287,7 +12287,7 @@
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "cPu" = (
 /obj/effect/spawner/random{
-	loot = list(/obj/effect/decal/cleanable/oil/slippery=10,/obj/effect/decal/cleanable/oil=90);
+	loot = list(/obj/effect/decal/cleanable/oil/slippery = 10, /obj/effect/decal/cleanable/oil = 90);
 	name = "funny slipper :)"
 	},
 /turf/open/floor/noslip/tram_plate,
@@ -14853,9 +14853,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "dNB" = (
@@ -17321,7 +17318,7 @@
 	},
 /obj/machinery/elevator_control_panel/directional/west{
 	linked_elevator_id = "tram_sci_lift";
-	preset_destination_names = list("2"="Lower Deck","3"="Upper Deck")
+	preset_destination_names = list("2" = "Lower Deck", "3" = "Upper Deck")
 	},
 /turf/open/floor/plating/elevatorshaft,
 /area/station/science/lower)
@@ -17618,6 +17615,7 @@
 /obj/item/scalpel{
 	pixel_y = 11
 	},
+/obj/item/clothing/mask/breath/medical,
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "eRb" = (
@@ -19104,11 +19102,11 @@
 	codes_txt = "delivery;dir=1";
 	location = "QM #6"
 	},
+/obj/effect/turf_decal/tile/brown/fourcorners,
 /mob/living/simple_animal/bot/mulebot{
 	home_destination = "QM #6";
 	suffix = "#6"
 	},
-/obj/effect/turf_decal/tile/brown/fourcorners,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "ftm" = (
@@ -19421,7 +19419,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area)
+/area/station/science/ordnance/testlab)
 "fyc" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner,
 /turf/open/floor/iron,
@@ -22145,7 +22143,7 @@
 	desc = "A small control panel used to move the kitchen dumbwaiter up and down.";
 	linked_elevator_id = "dumbwaiter_lift";
 	name = "Dumbwaiter control Panel";
-	preset_destination_names = list("2"="Hydroponics","3"="Kitchen")
+	preset_destination_names = list("2" = "Hydroponics", "3" = "Kitchen")
 	},
 /obj/effect/turf_decal/tile/green/fourcorners,
 /turf/open/floor/iron/dark,
@@ -27245,6 +27243,7 @@
 /obj/structure/bed/roller,
 /obj/machinery/iv_drip,
 /obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "iEz" = (
@@ -30670,6 +30669,19 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/security/processing)
+"jPL" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/delivery/white{
+	color = "#52B4E9"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "jPM" = (
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
@@ -31198,6 +31210,7 @@
 /area/station/medical/chemistry)
 "jZa" = (
 /obj/machinery/light/small/directional/west,
+/obj/structure/tank_holder/anesthetic,
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "jZb" = (
@@ -41951,7 +41964,7 @@
 	},
 /obj/machinery/elevator_control_panel/directional/west{
 	linked_elevator_id = "tram_perma_lift";
-	preset_destination_names = list("2"="Lower Deck","3"="Upper Deck")
+	preset_destination_names = list("2" = "Lower Deck", "3" = "Upper Deck")
 	},
 /turf/open/floor/plating/elevatorshaft,
 /area/station/security/execution/transfer)
@@ -43819,7 +43832,7 @@
 /obj/machinery/elevator_control_panel{
 	linked_elevator_id = "tram_xeno_lift";
 	pixel_y = 2;
-	preset_destination_names = list("2"="Lower Deck","3"="Upper Deck");
+	preset_destination_names = list("2" = "Lower Deck", "3" = "Upper Deck");
 	layer = 3.1
 	},
 /turf/closed/wall,
@@ -43935,7 +43948,7 @@
 /obj/structure/industrial_lift/public,
 /obj/machinery/elevator_control_panel/directional/south{
 	linked_elevator_id = "tram_dorm_lift";
-	preset_destination_names = list("2"="Lower Deck","3"="Upper Deck")
+	preset_destination_names = list("2" = "Lower Deck", "3" = "Upper Deck")
 	},
 /obj/structure/railing,
 /turf/open/floor/plating/elevatorshaft,
@@ -44859,7 +44872,7 @@
 	},
 /obj/effect/turf_decal/box/red,
 /turf/open/floor/iron/dark,
-/area)
+/area/station/science/ordnance/testlab)
 "oYs" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -45868,11 +45881,11 @@
 	codes_txt = "delivery;dir=2";
 	location = "QM #3"
 	},
+/obj/effect/turf_decal/tile/brown/fourcorners,
 /mob/living/simple_animal/bot/mulebot{
 	home_destination = "QM #3";
 	suffix = "#3"
 	},
-/obj/effect/turf_decal/tile/brown/fourcorners,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "pso" = (
@@ -51261,7 +51274,7 @@
 	},
 /obj/machinery/elevator_control_panel/directional/north{
 	linked_elevator_id = "tram_upper_center_lift";
-	preset_destination_names = list("2"="Lower Deck","3"="Upper Deck")
+	preset_destination_names = list("2" = "Lower Deck", "3" = "Upper Deck")
 	},
 /obj/effect/turf_decal/trimline/dark_red/warning{
 	dir = 1
@@ -52253,7 +52266,7 @@
 /obj/structure/industrial_lift/public,
 /obj/machinery/elevator_control_panel/directional/east{
 	linked_elevator_id = "tram_lower_center_lift";
-	preset_destination_names = list("2"="Lower Deck","3"="Upper Deck")
+	preset_destination_names = list("2" = "Lower Deck", "3" = "Upper Deck")
 	},
 /turf/open/floor/plating/elevatorshaft,
 /area/station/maintenance/tram/mid)
@@ -55165,7 +55178,7 @@
 	},
 /obj/item/reagent_containers/cup/bottle{
 	desc = "A small bottle of Barber's Aid.";
-	list_reagents = list(/datum/reagent/barbers_aid=30);
+	list_reagents = list(/datum/reagent/barbers_aid = 30);
 	name = "Barber's Aid bottle";
 	pixel_x = 10;
 	pixel_y = 3
@@ -55248,7 +55261,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/button/door/directional/north{
-	id = "midtunnelleft";
+	id = "lefttunnel";
 	name = "Tunnel Access Shutters Toggle"
 	},
 /turf/open/floor/plating,
@@ -63873,9 +63886,6 @@
 /obj/effect/turf_decal/trimline/white/warning,
 /turf/open/floor/iron,
 /area/station/maintenance/tram/left)
-"vDd" = (
-/turf/closed/wall/r_wall,
-/area)
 "vDg" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/effect/landmark/event_spawn,
@@ -65929,8 +65939,8 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/mob/living/simple_animal/bot/secbot/beepsky,
 /obj/effect/landmark/event_spawn,
+/mob/living/simple_animal/bot/secbot/beepsky,
 /turf/open/floor/iron,
 /area/station/hallway/primary/tram/center)
 "wrT" = (
@@ -68621,11 +68631,11 @@
 	codes_txt = "delivery;dir=2";
 	location = "QM #1"
 	},
+/obj/effect/turf_decal/tile/brown/fourcorners,
 /mob/living/simple_animal/bot/mulebot{
 	home_destination = "QM #1";
 	suffix = "#1"
 	},
-/obj/effect/turf_decal/tile/brown/fourcorners,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "xxZ" = (
@@ -70219,20 +70229,20 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "ydU" = (
+/obj/effect/landmark/lift_id{
+	specific_lift_id = "tram_cargo_lift"
+	},
+/obj/structure/railing{
+	dir = 8
+	},
 /obj/effect/turf_decal/trimline/dark_red/warning{
 	dir = 8
 	},
 /obj/structure/industrial_lift/public,
 /obj/machinery/elevator_control_panel/directional/west{
 	linked_elevator_id = "tram_cargo_lift";
-	preset_destination_names = list("2"="Lower Deck","3"="Upper Deck");
+	preset_destination_names = list("2" = "Lower Deck", "3" = "Upper Deck");
 	req_access = list("mining")
-	},
-/obj/effect/landmark/lift_id{
-	specific_lift_id = "tram_cargo_lift"
-	},
-/obj/structure/railing{
-	dir = 8
 	},
 /obj/effect/abstract/elevator_music_zone{
 	linked_elevator_id = "tram_cargo_lift"
@@ -122245,8 +122255,8 @@ aaa
 aaa
 aaa
 frV
-vDd
-vDd
+frV
+frV
 frV
 frV
 frV
@@ -172352,7 +172362,7 @@ clT
 clT
 oIa
 dPo
-jtM
+jPL
 oZq
 vrU
 std


### PR DESCRIPTION
Closes: #6096
Closes: #6097
Closes: #6106
## Changelog

:cl: Crushtoe, Potato-Masher, Zargoar
fix: Crushtoe: Fixed tram morgue mapping issues and underpass shutter buttons.
fix: Potato-Masher: Removes the misplaced extra chem dispenser from NorthStar pharmacy.
fix: Potato-Masher: NorthStar medbay now has lightswitches in some rooms as opposed to none.
qol: Zargoar: adds further flavor to the Northstar Plushies
/:cl:

