### PR TITLE
Maybe fixes Pubby CI

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -16699,6 +16699,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/incident_display/delam/directional/north,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "fpa" = (
@@ -18221,11 +18222,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"geC" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/incident_display/delam/directional/south,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
 "geV" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -52074,6 +52070,7 @@
 /area/station/science/ordnance/testlab)
 "vUl" = (
 /obj/machinery/modular_computer/preset/engineering,
+/obj/machinery/incident_display/delam/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "vUz" = (
@@ -55250,7 +55247,6 @@
 /obj/item/kirbyplants/organic/plant2,
 /obj/structure/sign/departments/engineering/directional/south,
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/incident_display/delam/directional/east,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "xkK" = (
@@ -87952,7 +87948,7 @@ stj
 stj
 sPr
 vBj
-geC
+pDG
 uRk
 lkb
 npv


### PR DESCRIPTION
The delam counters aren't true directionals I hate this.

## Changelog

:cl: Jolly
fix: [PubbyStation] There should no longer be a floating delam counter outside Engineering.
/:cl:

