### PR TITLE
Sprite edits are now always tagged

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -11,6 +11,10 @@ Map Edit:
   - '**/*.dmm'
   - '_maps/**'
 
+# Changes to a .dmi
+Sprites:
+- '**/*.dmi'
+
 # Tools
 Tools:
   - 'tools/**'


### PR DESCRIPTION
Not every PR will have a images prefix. This makes sprite PRs a little more obvious.