### PR TITLE
Tower caps and anything non-consumable can now be turned into seeds

### DIFF
--- a/talestation_modules/code/xenobotany_module/produce/seeds.dm
+++ b/talestation_modules/code/xenobotany_module/produce/seeds.dm
@@ -2,13 +2,21 @@
 
 // Adds this var to the primary seeds parent typepath
 /obj/item/seeds
+	/// Are we an alien seed?
 	var/is_alien_seeds = FALSE
 
 // Modular override to add the alien var
 /obj/item/food/grown
+	/// Are we an alien food item?
+	var/is_alien_produce = FALSE
+
+// what the fuck is going on here
+/obj/item/grown
+	/// Are we an alien non-food item?
 	var/is_alien_produce = FALSE
 
 // Alien seeds used for XenoBotany
+// Kinda just a shitty slot in for later cause I'm lazy
 /obj/item/seeds/xeno
 	is_alien_seeds = TRUE
 	name = "pack of extradimensional orange seeds"


### PR DESCRIPTION
Closes: #6792

Also documented the code a wee bit.

## Changelog

:cl: Jolly
fix: Tower caps can now be turned into seeds (and anything else that can be grown and is NOT a food item)
/:cl:
