### PR TITLE
"Fixes" assistants being unable to use Loadouts for uniforms

### DIFF
--- a/code/modules/jobs/job_types/assistant.dm
+++ b/code/modules/jobs/job_types/assistant.dm
@@ -43,9 +43,11 @@ Assistant
 	id_trim = /datum/id_trim/job/assistant
 	belt = /obj/item/modular_computer/pda/assistant
 
+/*
 /datum/outfit/job/assistant/pre_equip(mob/living/carbon/human/target)
 	..()
 	give_jumpsuit(target)
+*/
 
 /datum/outfit/job/assistant/proc/give_jumpsuit(mob/living/carbon/human/target)
 	var/static/jumpsuit_number = 0

--- a/code/modules/jobs/job_types/assistant.dm
+++ b/code/modules/jobs/job_types/assistant.dm
@@ -43,7 +43,7 @@ Assistant
 	id_trim = /datum/id_trim/job/assistant
 	belt = /obj/item/modular_computer/pda/assistant
 
-/*
+/* NON-MODULAR CHANGES: Disables this since it conflicts with loadouts
 /datum/outfit/job/assistant/pre_equip(mob/living/carbon/human/target)
 	..()
 	give_jumpsuit(target)


### PR DESCRIPTION
Fixes #6793 but in a shitty way.

It's not a clean fix, but its a "fix".
I wanna look into this later when I can think better.

## Changelog

:cl: Jolly
fix: Assistants can now use loadouts to change their uniforms. However, their base suits are now grey.
/:cl: