### PR TITLE
Flavor text should no longer be obscured if something is in your mask slot that wouldn't naturally obscure your face

### DIFF
--- a/talestation_modules/code/clothing_module/clothing.dm
+++ b/talestation_modules/code/clothing_module/clothing.dm
@@ -1,10 +1,3 @@
-/obj/item/clothing
-	/* Determines if our head-related item doesn't obscures flavor text
-	* Usually hoods or masks
-	* Used to check if our flavor test is obscured
-	*/
-	var/covers_face = FALSE
-
-/obj/item/food/bubblegum
-	/// Used for not hiding flavor text
+/obj/item
+	/// Determines if something covers our face, obscuring our flavor text
 	var/covers_face = FALSE


### PR DESCRIPTION
Fixes: #6401
I don't feel like combing code, sorta a bad solution but it's a solution.

## Changelog

:cl: Jolly
fix: Flavor text should no longer break due to code related mishaps.
/:cl:
