### PR TITLE
Languages are now more consistent 

### DIFF
--- a/talestation_modules/code/prefs_module/languages.dm
+++ b/talestation_modules/code/prefs_module/languages.dm
@@ -52,8 +52,8 @@
 	/// The 'required species' of the language, languages that require you be a certain species to know.
 	var/req_species
 
-/datum/language/skrell
-	base_species = SPECIES_SKRELL
+/datum/language/calcic
+	base_species = SPECIES_PLASMAMAN
 
 /datum/language/draconic
 	base_species = SPECIES_LIZARD
@@ -61,14 +61,26 @@
 /datum/language/impdraconic
 	req_species = SPECIES_LIZARD
 
-/datum/language/nekomimetic
-	base_species = SPECIES_FELINE
-
 /datum/language/moffic
 	base_species = SPECIES_MOTH
 
+/datum/language/nekomimetic
+	base_species = SPECIES_FELINE
+
+/datum/language/skrell
+	base_species = SPECIES_SKRELL
+
+/datum/language/slime
+	base_species = SPECIES_JELLYPERSON
+
+/datum/language/sylvan
+	base_species = SPECIES_PODPERSON
+
 /datum/language/tajaran
 	base_species = SPECIES_TAJARAN
+
+/datum/language/voltaic
+	base_species = SPECIES_ETHEREAL
 
 /// TGUI for selecting languages.
 /datum/language_picker

--- a/talestation_modules/code/species_module/languages/language_holder.dm
+++ b/talestation_modules/code/species_module/languages/language_holder.dm
@@ -1,5 +1,0 @@
-// -- Overrides and extensions for language holders. --
-/datum/language_holder/synthetic/New(atom/_owner)
-	understood_languages |= list(/datum/language/skrell = list(LANGUAGE_ATOM), /datum/language/impdraconic = list(LANGUAGE_ATOM), /datum/language/tajaran = list(LANGUAGE_ATOM))
-	spoken_languages |= list(/datum/language/skrell = list(LANGUAGE_ATOM), /datum/language/impdraconic = list(LANGUAGE_ATOM), /datum/language/tajaran = list(LANGUAGE_ATOM))
-	return ..()

--- a/talestation_modules/code/species_module/languages/tajaranese.dm
+++ b/talestation_modules/code/species_module/languages/tajaranese.dm
@@ -1,9 +1,9 @@
 /// Tajaran langauge
 /datum/language/tajaran
 	name = "Tajaranese"
-	desc = "What's describe as 'psp psp psp with a lot of love', Tajaranese is the langauge \
+	desc = "What's described as 'psp psp psp with a lot of love', Tajaranese is the langauge \
 			of Tajarans, if the name itself wasn't a giveaway."
-	key = "t"
+	key = "q"
 	space_chance = 75
 	syllables = list(
 		"psp", "pspsp", "mow", "mraw", "mwa", "maawh", "psssp", "psspss")

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5632,7 +5632,6 @@
 #include "talestation_modules\code\species_module\jelly_people\jelly.dm"
 #include "talestation_modules\code\species_module\jelly_people\jelly_quirks.dm"
 #include "talestation_modules\code\species_module\languages\highdraconic.dm"
-#include "talestation_modules\code\species_module\languages\language_holder.dm"
 #include "talestation_modules\code\species_module\languages\skrellian.dm"
 #include "talestation_modules\code\species_module\languages\tajaranese.dm"
 #include "talestation_modules\code\species_module\lizard\lizard_organs.dm"


### PR DESCRIPTION
Fixes: #6689

Adds more roundstart languages to the list. Also organizes the code alphabetically a bit.
Kinda don't like how this list is handled but what can you do.

## Changelog

:cl: Jolly
fix: More round-start languages have been added to the language picker.
/:cl:
