### PR TITLE
Rips out the code for job exp play times

### DIFF
--- a/talestation_modules/code/jobs_module/asset_protection/ap_define.dm
+++ b/talestation_modules/code/jobs_module/asset_protection/ap_define.dm
@@ -11,7 +11,6 @@
 	supervisors = SUPERVISOR_COMMAND
 	req_admin_notify = TRUE
 	minimal_player_age = 10
-	exp_requirements = 3000
 	exp_required_type = EXP_TYPE_CREW
 	exp_required_type_department = EXP_TYPE_COMMAND
 	exp_granted_type = EXP_TYPE_COMMAND

--- a/talestation_modules/code/jobs_module/bridge_officer/bo_define.dm
+++ b/talestation_modules/code/jobs_module/bridge_officer/bo_define.dm
@@ -11,7 +11,6 @@
 	supervisors = SUPERVISOR_COMMAND
 	req_admin_notify = 1
 	minimal_player_age = 10
-	exp_requirements = 3000
 	exp_required_type = EXP_TYPE_CREW
 	exp_required_type_department = EXP_TYPE_COMMAND
 	exp_granted_type = EXP_TYPE_COMMAND

--- a/talestation_modules/code/jobs_module/exp_rep.dm
+++ b/talestation_modules/code/jobs_module/exp_rep.dm
@@ -1,11 +1,9 @@
-// Modular var override for exp reqs for jobs
-// DO NOT ADD TO THIS FILE UNLESS ITS TO TWEAK THE VAR FOR PLAYTIMES
-
-/datum/job/ai
-	exp_requirements = 2400
+/*
+* All this filee does is set exp_req and exp_granted types for jobs
+* I wish jobconfig.tmol did this :/
+*/
 
 /datum/job/atmospheric_technician
-	exp_requirements = 300
 	exp_required_type = EXP_TYPE_ENGINEERING
 	exp_granted_type = EXP_TYPE_ENGINEERING
 
@@ -16,7 +14,6 @@
 	exp_granted_type = EXP_TYPE_SERVICE
 
 /datum/job/captain
-	exp_requirements = 2400
 	exp_required_type = EXP_TYPE_COMMAND
 	exp_required_type_department = EXP_TYPE_COMMAND
 	exp_granted_type = EXP_TYPE_COMMAND
@@ -28,17 +25,14 @@
 	exp_granted_type = EXP_TYPE_SERVICE
 
 /datum/job/chemist
-	exp_requirements = 0
 	exp_granted_type = EXP_TYPE_MEDICAL
 
 /datum/job/chief_engineer
-	exp_requirements = 2400
 	exp_required_type = EXP_TYPE_ENGINEERING
 	exp_required_type_department = EXP_TYPE_ENGINEERING
 	exp_granted_type = EXP_TYPE_COMMAND
 
 /datum/job/chief_medical_officer
-	exp_requirements = 2400
 	exp_required_type = EXP_TYPE_MEDICAL
 	exp_required_type_department = EXP_TYPE_MEDICAL
 	exp_granted_type = EXP_TYPE_COMMAND
@@ -53,28 +47,23 @@
 	exp_granted_type = EXP_TYPE_SERVICE
 
 /datum/job/cyborg
-	exp_requirements = 1200
 	exp_required_type = EXP_TYPE_SILICON
 	exp_granted_type = EXP_TYPE_SILICON
 
 /datum/job/detective
-	exp_requirements = 600
 	exp_required_type = EXP_TYPE_SECURITY
 	exp_granted_type = EXP_TYPE_SECURITY
 
 /datum/job/geneticist
-	exp_requirements = 0
 	exp_required_type = EXP_TYPE_SCIENCE
 	exp_granted_type = EXP_TYPE_SCIENCE
 
 /datum/job/head_of_personnel
-	exp_requirements = 2400
 	exp_required_type = EXP_TYPE_SERVICE
 	exp_required_type_department = EXP_TYPE_SERVICE
 	exp_granted_type = EXP_TYPE_COMMAND
 
 /datum/job/head_of_security
-	exp_requirements = 2400
 	exp_required_type = EXP_TYPE_SECURITY
 	exp_required_type_department = EXP_TYPE_SECURITY
 	exp_granted_type = EXP_TYPE_COMMAND
@@ -98,28 +87,23 @@
 	exp_granted_type = EXP_TYPE_SERVICE
 
 /datum/job/quartermaster
-	exp_requirements = 2400
 	exp_required_type_department = EXP_TYPE_SUPPLY
 	exp_granted_type = EXP_TYPE_COMMAND
 
 /datum/job/research_director
-	exp_requirements = 2400
 	exp_required_type_department = EXP_TYPE_SCIENCE
 	exp_required_type = EXP_TYPE_SCIENCE
 	exp_granted_type = EXP_TYPE_COMMAND
 
 /datum/job/roboticist
-	exp_requirements = 180
 	exp_required_type = EXP_TYPE_SCIENCE
 	exp_granted_type = EXP_TYPE_SCIENCE
 
 /datum/job/scientist
-	exp_requirements = 0
 	exp_required_type = EXP_TYPE_SCIENCE
 	exp_granted_type = EXP_TYPE_SCIENCE
 
 /datum/job/security_officer
-	exp_requirements = 0
 	exp_required_type = EXP_TYPE_SECURITY
 	exp_granted_type = EXP_TYPE_SECURITY
 
@@ -127,16 +111,13 @@
 	exp_granted_type = EXP_TYPE_SUPPLY
 
 /datum/job/station_engineer
-	exp_requirements = 0
 	exp_required_type = EXP_TYPE_SERVICE
 	exp_granted_type = EXP_TYPE_ENGINEERING
 
 /datum/job/virologist
-	exp_requirements = 300
 	exp_required_type = EXP_TYPE_MEDICAL
 	exp_granted_type = EXP_TYPE_MEDICAL
 
 /datum/job/warden
-	exp_requirements = 900
 	exp_required_type = EXP_TYPE_SECURITY
 	exp_granted_type = EXP_TYPE_SECURITY


### PR DESCRIPTION
I hope this fixes stuff.

## Changelog

:cl: Jolly
del: Deleted the code defines for job exp requirements. They should be handled by config now, hopefully?
/:cl:
