### PR TITLE
Renames our map command stuff

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -6270,7 +6270,7 @@
 	base_state = "rightsecure";
 	dir = 1;
 	icon_state = "rightsecure";
-	name = "Head of Personnel's Desk";
+	name = "Asset Clerk's Desk";
 	req_access = list("hop")
 	},
 /obj/machinery/door/window/right/directional/south{
@@ -13103,8 +13103,8 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/requests_console/directional/south{
-	department = "Captain's Desk";
-	name = "Captain's Requests Console"
+	department = "Site Director's Desk";
+	name = "Site Director's Requests Console"
 	},
 /obj/effect/mapping_helpers/requests_console/announcement,
 /obj/effect/mapping_helpers/requests_console/information,
@@ -17369,8 +17369,8 @@
 /obj/structure/table/wood,
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/fax{
-	fax_name = "Captain's Office";
-	name = "Captain's Fax Machine"
+	fax_name = "Site Director's Office";
+	name = "Site Director's Fax Machine"
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -22599,8 +22599,8 @@
 	},
 /obj/structure/table,
 /obj/machinery/fax{
-	fax_name = "Head of Personnel's Office";
-	name = "Head of Personnel's Fax Machine"
+	fax_name = "Asset Clerk's Office";
+	name = "Asset Clerk's Fax Machine"
 	},
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -24448,7 +24448,7 @@
 /area/station/cargo/office)
 "hUy" = (
 /obj/machinery/door/airlock/command{
-	name = "Captain's Quarters"
+	name = "Site Director's Quarters"
 	},
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
@@ -26749,15 +26749,15 @@
 "iBU" = (
 /obj/structure/table/glass,
 /obj/machinery/requests_console/directional/north{
-	department = "Chief Medical Officer's Desk";
-	name = "Chief Medical Officer's Requests Console"
+	department = "Medical Director's Desk";
+	name = "Medical Director's Requests Console"
 	},
 /obj/effect/mapping_helpers/requests_console/announcement,
 /obj/effect/mapping_helpers/requests_console/information,
 /obj/effect/mapping_helpers/requests_console/assistance,
 /obj/machinery/fax{
-	fax_name = "Chief Medical Officer's Office";
-	name = "Chief Medical Officer's Fax Machine"
+	fax_name = "Medical Director's Office";
+	name = "Medical Director's Fax Machine"
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -27046,7 +27046,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/command{
-	name = "Chief Medical Officer's Office"
+	name = "Medical Director's Office"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -33211,7 +33211,7 @@
 	},
 /obj/structure/noticeboard/directional/north,
 /obj/machinery/camera/directional/north{
-	c_tag = "Head of Personnel's Office";
+	c_tag = "Asset Clerk's Office";
 	name = "command camera"
 	},
 /obj/effect/turf_decal/siding/wood{
@@ -38120,7 +38120,7 @@
 "mqa" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
-	name = "Head of Personnel's Office"
+	name = "Asset Clerk's Office"
 	},
 /obj/effect/landmark/navigate_destination,
 /obj/effect/turf_decal/siding/wood/corner{
@@ -39049,7 +39049,7 @@
 /area/station/engineering/atmos/storage/gas)
 "mHc" = (
 /obj/machinery/door/airlock/command{
-	name = "Captain's Office"
+	name = "Site Director's Office"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "bridge-passthrough"
@@ -42387,7 +42387,7 @@
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 8;
 	id = "ceprivate";
-	name = "Chief Engineer's Privacy Shutters"
+	name = "Site Foreman's Privacy Shutters"
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/caution/stand_clear,
@@ -46190,7 +46190,7 @@
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 8;
 	id = "ceprivate";
-	name = "Chief Engineer's Privacy Shutters"
+	name = "Site Foreman's Privacy Shutters"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -46812,7 +46812,7 @@
 "pqF" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
-	name = "Chief Engineer's Office"
+	name = "Site Foreman's Office"
 	},
 /obj/effect/turf_decal/siding/yellow/corner{
 	dir = 4
@@ -49992,7 +49992,7 @@
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
-	name = "Head of Personnel's Office"
+	name = "Asset Clerk's Office"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53120,8 +53120,8 @@
 	dir = 4
 	},
 /obj/machinery/requests_console/directional/west{
-	department = "Head of Personnel's Desk";
-	name = "Head of Personnel's Requests Console"
+	department = "Asset Clerk's Desk";
+	name = "Asset Clerk's Requests Console"
 	},
 /obj/effect/mapping_helpers/requests_console/announcement,
 /obj/effect/mapping_helpers/requests_console/information,
@@ -55094,8 +55094,8 @@
 "sdp" = (
 /obj/structure/table/reinforced,
 /obj/machinery/fax{
-	fax_name = "Chief Engineer's Office";
-	name = "Chief Engineer's Fax Machine"
+	fax_name = "Site Foreman's Office";
+	name = "Site Foreman's Fax Machine"
 	},
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron/dark,
@@ -55646,7 +55646,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "ceprivate";
-	name = "Chief Engineer's Privacy Shutters"
+	name = "Site Foreman's Privacy Shutters"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -60013,7 +60013,7 @@
 /area/station/hallway/primary/aft)
 "tGS" = (
 /obj/machinery/camera/directional/north{
-	c_tag = "Captain's Office";
+	c_tag = "Site Director's Office";
 	name = "command camera"
 	},
 /obj/structure/chair/comfy/brown{
@@ -63202,7 +63202,7 @@
 "uJs" = (
 /obj/machinery/computer/security/telescreen/cmo{
 	dir = 1;
-	name = "Chief Medical Officer's telescreen";
+	name = "Medical Director's telescreen";
 	network = list("medical");
 	pixel_y = 2
 	},
@@ -64132,7 +64132,7 @@
 /obj/item/clipboard,
 /obj/item/toy/figure/captain,
 /obj/machinery/camera/directional/north{
-	c_tag = "Captain's Quarters";
+	c_tag = "Site Director's Quarters";
 	name = "command camera"
 	},
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -65070,7 +65070,7 @@
 /obj/structure/noticeboard/directional/east,
 /obj/item/paper/monitorkey,
 /obj/machinery/camera/directional/east{
-	c_tag = "Chief Engineer's Office";
+	c_tag = "Site Foreman's Office";
 	name = "engineering camera";
 	network = list("ss13","engine")
 	},
@@ -65996,8 +65996,8 @@
 /obj/machinery/computer/apc_control,
 /obj/effect/turf_decal/bot,
 /obj/machinery/requests_console/directional/west{
-	department = "Chief Engineer's Desk";
-	name = "Chief Engineer's Requests Console"
+	department = "Site Foreman's Desk";
+	name = "Site Foreman's Requests Console"
 	},
 /obj/effect/mapping_helpers/requests_console/announcement,
 /obj/effect/mapping_helpers/requests_console/supplies,
@@ -68842,7 +68842,7 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/newscaster/directional/north,
 /obj/machinery/camera/directional/north{
-	c_tag = "Chief Medical Officer's Office";
+	c_tag = "Medical Director's Office";
 	name = "medical camera";
 	network = list("ss13","medical")
 	},
@@ -72444,7 +72444,7 @@
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 8;
 	id = "ceprivate";
-	name = "Chief Engineer's Privacy Shutters"
+	name = "Site Foreman's Privacy Shutters"
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/caution/stand_clear,
@@ -73013,7 +73013,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/command{
-	name = "Captain's Office"
+	name = "Site Director's Office"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -73268,7 +73268,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/command{
-	name = "Chief Engineer's Office"
+	name = "Site Foreman's Office"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4

--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -9161,7 +9161,7 @@
 	dir = 1
 	},
 /obj/machinery/door/airlock/command{
-	name = "Captains Office"
+	name = "Site Director's Office"
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
@@ -12356,13 +12356,13 @@
 "faU" = (
 /obj/machinery/computer/station_alert,
 /obj/machinery/camera{
-	c_tag = "Command - Chief Engineer's Office";
+	c_tag = "Command - Site Foreman's Office";
 	dir = 9;
 	network = list("ss13","engine")
 	},
 /obj/machinery/requests_console{
-	department = "Chief Engineer's Desk";
-	name = "Chief Engineer RC";
+	department = "Site Foreman's Desk";
+	name = "Site Foreman RC";
 	pixel_y = 30
 	},
 /obj/effect/mapping_helpers/requests_console/announcement,
@@ -15458,7 +15458,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/any/command/captain,
 /obj/machinery/door/airlock/command{
-	name = "Captains Quarters"
+	name = "Site Director's Quarter"
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain/private)
@@ -23836,7 +23836,7 @@
 "jvQ" = (
 /obj/structure/closet/secure_closet/hop,
 /obj/machinery/camera{
-	c_tag = "Command - Head of Personnel's Office";
+	c_tag = "Command - Asset Clerk's Office";
 	dir = 8
 	},
 /turf/open/floor/wood,
@@ -25555,7 +25555,7 @@
 /area/station/security/office)
 "kaZ" = (
 /obj/machinery/door/window/right/directional/north{
-	name = "Captain's Desk Door";
+	name = "Site Director's Desk Door";
 	req_access = list("captain")
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -26160,7 +26160,7 @@
 	},
 /obj/item/radio/intercom/directional/south{
 	freerange = 1;
-	name = "Captain's Intercom"
+	name = "Site Director's Intercom"
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -27820,8 +27820,8 @@
 /area/station/maintenance/central)
 "kTs" = (
 /obj/machinery/requests_console{
-	department = "Chief Medical Officer's Desk";
-	name = "Chief Medical Officer RC";
+	department = "Medical Director's Desk";
+	name = "Medical Director RC";
 	pixel_y = 30
 	},
 /obj/effect/mapping_helpers/requests_console/announcement,
@@ -29638,7 +29638,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/ce,
 /obj/effect/landmark/navigate_destination,
 /obj/machinery/door/airlock/command{
-	name = "Chief Engineer's Office"
+	name = "Site Foreman's Office"
 	},
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
@@ -32780,7 +32780,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/command/hop,
 /obj/effect/landmark/navigate_destination/hop,
 /obj/machinery/door/airlock/command{
-	name = "Head of Personnel's Office"
+	name = "Asset Clerk's Office"
 	},
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/hop)
@@ -33707,7 +33707,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/medical/cmo,
 /obj/machinery/door/airlock/command{
-	name = "Chief Medical Officer's Office"
+	name = "Medical Director's Office"
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/command/heads_quarters/cmo)
@@ -34737,7 +34737,7 @@
 	dir = 8
 	},
 /obj/machinery/camera{
-	c_tag = "Command - Chief Medical Officer's Office";
+	c_tag = "Command - Medical Director's Office";
 	dir = 4;
 	network = list("ss13","medbay")
 	},
@@ -36698,8 +36698,8 @@
 /area/station/maintenance/starboard/aft)
 "ohe" = (
 /obj/machinery/requests_console{
-	department = "Head of Personnel's Desk";
-	name = "Head of Personnel RC";
+	department = "Asset Clerk's Desk";
+	name = "Asset Clerk RC";
 	pixel_y = -30
 	},
 /obj/effect/mapping_helpers/requests_console/announcement,
@@ -50660,7 +50660,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/command/hop,
 /obj/machinery/door/airlock/command/glass{
-	name = "Head of Station Pet's Office"
+	name = "Asset Clerk's Pet Office"
 	},
 /turf/open/floor/iron,
 /area/station/command/corporate_showroom)
@@ -50747,7 +50747,7 @@
 "tmK" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/door/airlock/command{
-	name = "Captains Bathroom"
+	name = "Site Director's Bathroom"
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain/private)
@@ -55399,7 +55399,7 @@
 	name = "Privacy Shutters"
 	},
 /obj/machinery/door/window/brigdoor/right/directional/south{
-	name = "Head of Personnel's Desk";
+	name = "Asset Clerk's Desk";
 	req_access = list("hop")
 	},
 /obj/machinery/door/window/left/directional/north{
@@ -56414,7 +56414,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/command/hop,
 /obj/machinery/door/airlock/command/glass{
-	name = "Head of Station Pet's Office"
+	name = "Asset Clerk's Pet Office"
 	},
 /turf/open/floor/wood,
 /area/station/command/corporate_showroom)
@@ -57945,8 +57945,8 @@
 /area/station/science/genetics)
 "wfP" = (
 /obj/machinery/requests_console{
-	department = "Captain's Desk";
-	name = "Captain RC";
+	department = "Site Director's Desk";
+	name = "Site Director RC";
 	pixel_y = 30
 	},
 /obj/effect/mapping_helpers/requests_console/announcement,

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -2118,7 +2118,7 @@
 /area/station/command/heads_quarters/captain)
 "ayZ" = (
 /obj/machinery/door/window/left/directional/west{
-	name = "Captain's Desk";
+	name = "Site Director's Desk";
 	req_access = list("captain")
 	},
 /turf/open/floor/carpet,
@@ -2938,7 +2938,7 @@
 	base_state = "rightsecure";
 	dir = 1;
 	icon_state = "rightsecure";
-	name = "Head of Personnel's Desk";
+	name = "Asset Clerk's Desk";
 	req_access = list("hop")
 	},
 /obj/machinery/door/window/left/directional/north{
@@ -10503,7 +10503,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/command/hop,
 /obj/machinery/door/airlock/command{
-	name = "Head of Personnel's Office"
+	name = "Asset Clerk's Office"
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
@@ -10936,7 +10936,7 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "cGA" = (
 /obj/machinery/camera/directional/east{
-	c_tag = "Captain's Office"
+	c_tag = "Site Director's Office"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -13414,8 +13414,8 @@
 	dir = 8
 	},
 /obj/machinery/requests_console/directional/west{
-	department = "Chief Medical Officer's Desk";
-	name = "Chief Medical Officer's Requests Console"
+	department = "Medical Director's Desk";
+	name = "Medical Director's Requests Console"
 	},
 /obj/effect/mapping_helpers/requests_console/announcement,
 /obj/effect/mapping_helpers/requests_console/information,
@@ -14099,8 +14099,8 @@
 	dir = 4
 	},
 /obj/machinery/requests_console/directional/north{
-	department = "Chief Engineer's Desk";
-	name = "Chief Engineer's Requests Console"
+	department = "Site Foreman's Desk";
+	name = "Site Foreman's Requests Console"
 	},
 /obj/effect/mapping_helpers/requests_console/announcement,
 /obj/effect/mapping_helpers/requests_console/information,
@@ -29965,7 +29965,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/command/captain,
 /obj/machinery/door/airlock/command{
-	name = "Captains Office"
+	name = "Site Director's Office"
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/captain)
@@ -32908,7 +32908,7 @@
 	},
 /obj/machinery/light/directional/north,
 /obj/machinery/camera/directional/north{
-	c_tag = "Head of Personnel's Office"
+	c_tag = "Asset Clerk's Office"
 	},
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/wood,
@@ -33527,7 +33527,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/command/captain,
 /obj/machinery/door/airlock/command{
-	name = "Captains Quarters"
+	name = "Site Director's Quarters"
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/captain)
@@ -36079,8 +36079,8 @@
 "oti" = (
 /obj/machinery/computer/communications,
 /obj/machinery/requests_console/directional/north{
-	department = "Captain's Desk";
-	name = "Captain's Requests Console"
+	department = "Site Director's Desk";
+	name = "Site Director's Requests Console"
 	},
 /obj/effect/mapping_helpers/requests_console/announcement,
 /obj/effect/mapping_helpers/requests_console/information,
@@ -41151,7 +41151,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/medical/cmo,
 /obj/machinery/door/airlock/command{
-	name = "Chief Medical Officer's Office"
+	name = "Medical Director's Office"
 	},
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
@@ -41283,8 +41283,8 @@
 	pixel_y = 2
 	},
 /obj/machinery/requests_console/directional/north{
-	department = "Head of Personnel's Desk";
-	name = "Head of Personnel's Requests Console"
+	department = "Asset Clerk's Desk";
+	name = "Asset Clerk's Requests Console"
 	},
 /obj/effect/mapping_helpers/requests_console/announcement,
 /obj/effect/mapping_helpers/requests_console/information,
@@ -43570,7 +43570,7 @@
 	dir = 8
 	},
 /obj/machinery/camera/directional/west{
-	c_tag = "Chief Medical Office";
+	c_tag = "Medical Director's Office";
 	network = list("ss13","medbay");
 	pixel_y = -22
 	},
@@ -45454,7 +45454,7 @@
 /obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/light/directional/north,
 /obj/machinery/camera/directional/north{
-	c_tag = "Chief Engineer's Office"
+	c_tag = "Site Foreman's Office"
 	},
 /obj/machinery/computer/security/telescreen/ce{
 	pixel_y = 30
@@ -45720,7 +45720,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/ce,
 /obj/machinery/door/airlock/command{
-	name = "Chief Engineer's Office"
+	name = "Site Foreman's Office"
 	},
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
@@ -52301,7 +52301,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/command/hop,
 /obj/machinery/door/airlock/command{
-	name = "Head of Personnel's Office"
+	name = "Asset Clerk's Office"
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hop)
@@ -55752,7 +55752,7 @@
 /obj/structure/closet/secure_closet/captains,
 /obj/machinery/light/directional/north,
 /obj/machinery/camera/directional/north{
-	c_tag = "Captain's Quarters"
+	c_tag = "Site Director's Quarters"
 	},
 /obj/item/clothing/suit/armor/riot/knight/blue,
 /obj/item/clothing/head/helmet/knight/blue,


### PR DESCRIPTION
Fixes: #6928

## Changelog

:cl: Jolly
spellcheck: Lima, Kilo and Pubby Maps should now use the correct names for command staff.
/:cl:
