### PR TITLE
Makes the pubby hop office less of a disaster

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -2377,6 +2377,16 @@
 	pixel_x = -22;
 	pixel_y = 4
 	},
+/obj/machinery/airalarm/directional/north,
+/obj/structure/table/wood,
+/obj/machinery/fax_machine/command,
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/hop)
+"aBA" = (
+/obj/machinery/computer/cargo/request,
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/hop)
+"aBB" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
 	layer = 2.9
@@ -2386,25 +2396,10 @@
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
-"aBA" = (
-/obj/machinery/computer/security/telescreen/vault{
-	pixel_y = 30
-	},
-/obj/machinery/computer/security/mining,
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/hop)
-"aBB" = (
-/obj/machinery/computer/cargo/request,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/hop)
 "aBC" = (
-/obj/structure/closet/secure_closet/hop,
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the monastery.";
-	name = "Monastery Monitor";
-	network = list("monastery");
-	pixel_y = 32
+/obj/machinery/photocopier,
+/obj/machinery/camera/directional/north{
+	c_tag = "Asset Clerk's Office"
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
@@ -2498,7 +2493,11 @@
 	pixel_x = -26;
 	pixel_y = 6
 	},
-/obj/machinery/photocopier,
+/obj/structure/table/wood,
+/obj/machinery/computer/security/telescreen/vault{
+	dir = 4;
+	pixel_y = 5
+	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "aCQ" = (
@@ -2683,17 +2682,29 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/carpet,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/carpet/cyan,
 /area/station/command/heads_quarters/hop)
 "aDX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/turf/open/floor/carpet,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/carpet/cyan,
 /area/station/command/heads_quarters/hop)
 "aDY" = (
 /obj/item/radio/intercom/directional/east,
-/turf/open/floor/carpet,
+/obj/machinery/modular_computer/preset/id{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/carpet/cyan,
 /area/station/command/heads_quarters/hop)
 "aEd" = (
 /turf/closed/wall,
@@ -2795,34 +2806,68 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "aEM" = (
 /obj/item/kirbyplants/organic/plant24,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "aEN" = (
 /obj/structure/table/wood,
-/obj/item/storage/box/pdas{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/storage/box/silver_ids,
-/obj/item/storage/box/ids,
 /obj/machinery/firealarm/directional/south,
-/turf/open/floor/wood,
+/obj/item/storage/box/pdas{
+	pixel_y = 6;
+	pixel_x = 5
+	},
+/obj/item/storage/box/silver_ids{
+	pixel_x = -5;
+	pixel_y = 2
+	},
+/obj/item/storage/box/ids{
+	pixel_y = 12;
+	pixel_x = -1
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/carpet/cyan,
 /area/station/command/heads_quarters/hop)
 "aEO" = (
-/obj/machinery/computer/records/security{
-	dir = 1
+/obj/structure/table/wood,
+/obj/machinery/computer/records/medical/laptop{
+	dir = 1;
+	pixel_y = 4
 	},
-/turf/open/floor/carpet,
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/carpet/cyan,
 /area/station/command/heads_quarters/hop)
 "aEP" = (
-/obj/machinery/modular_computer/preset/id{
-	dir = 4
+/obj/structure/table/wood,
+/obj/item/paper_bin/carbon{
+	layer = 2.9;
+	pixel_y = 4;
+	pixel_x = 6
 	},
-/turf/open/floor/carpet,
+/obj/item/stamp/head/hop{
+	pixel_x = -6;
+	pixel_y = 13
+	},
+/obj/item/stamp{
+	pixel_y = 6;
+	pixel_x = -8
+	},
+/obj/item/stamp/denied{
+	pixel_x = -5;
+	pixel_y = -1
+	},
+/obj/item/pen/fourcolor{
+	pixel_x = 6;
+	pixel_y = 7
+	},
+/obj/structure/cable,
+/turf/open/floor/carpet/cyan,
 /area/station/command/heads_quarters/hop)
 "aER" = (
 /obj/machinery/camera/directional/south{
@@ -5055,6 +5100,7 @@
 "bbU" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
+/obj/structure/closet/secure_closet/hop,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "bbV" = (
@@ -7006,7 +7052,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/carpet,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/carpet/cyan,
 /area/station/command/heads_quarters/hop)
 "bAF" = (
 /turf/closed/wall,
@@ -18988,9 +19038,6 @@
 	req_access = list("ap")
 	},
 /obj/structure/table/wood,
-/obj/item/radio/intercom/directional/south{
-	pixel_y = -38
-	},
 /obj/item/stamp/head/ap{
 	pixel_x = 9;
 	pixel_y = 7
@@ -32906,11 +32953,7 @@
 /obj/structure/filingcabinet/chestdrawer{
 	pixel_y = 2
 	},
-/obj/machinery/light/directional/north,
-/obj/machinery/camera/directional/north{
-	c_tag = "Asset Clerk's Office"
-	},
-/obj/machinery/newscaster/directional/north,
+/obj/machinery/light/warm/directional/north,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "mVj" = (
@@ -33748,8 +33791,8 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/captain)
 "noS" = (
-/obj/machinery/vending/cola,
 /obj/effect/turf_decal/delivery,
+/obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "noT" = (
@@ -35662,9 +35705,10 @@
 /obj/machinery/button/flasher{
 	id = "hopflash";
 	pixel_x = 38;
-	pixel_y = -25
+	pixel_y = -26
 	},
-/turf/open/floor/carpet,
+/obj/effect/landmark/start/head_of_personnel,
+/turf/open/floor/carpet/cyan,
 /area/station/command/heads_quarters/hop)
 "ojI" = (
 /obj/structure/filingcabinet,
@@ -50132,23 +50176,16 @@
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "uVZ" = (
-/obj/structure/table/wood,
-/obj/item/stamp/head/hop{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/machinery/button/ticket_machine{
-	pixel_x = 28
-	},
-/obj/item/paper_bin/carbon{
-	layer = 2.9
-	},
 /obj/machinery/button/door/directional/south{
 	id = "hop";
 	name = "Privacy Shutters Control";
 	req_access = list("hop");
 	pixel_x = -6;
 	pixel_y = -26
+	},
+/obj/machinery/button/ticket_machine{
+	pixel_x = 6;
+	pixel_y = -36
 	},
 /obj/machinery/button/door/directional/south{
 	id = "hopqueue";
@@ -50157,7 +50194,10 @@
 	pixel_x = -6;
 	pixel_y = -36
 	},
-/turf/open/floor/carpet,
+/obj/machinery/computer/records/security{
+	dir = 8
+	},
+/turf/open/floor/carpet/cyan,
 /area/station/command/heads_quarters/hop)
 "uWs" = (
 /obj/machinery/vending/assist,
@@ -55697,9 +55737,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/fax_machine/command,
 /obj/structure/table/wood,
-/turf/open/floor/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/item/flashlight/lamp,
+/turf/open/floor/carpet/cyan,
 /area/station/command/heads_quarters/hop)
 "xvh" = (
 /obj/effect/landmark/start/security_officer,
@@ -90695,8 +90738,8 @@ aCR
 aDU
 aEM
 mPp
-mpO
-iBr
+tVk
+aAN
 ihY
 phW
 jtv
@@ -91209,10 +91252,10 @@ aaT
 aDV
 aEO
 aAH
-tVk
+mpO
 iBr
-ozL
-phW
+hJd
+okK
 xzk
 anX
 wWm
@@ -91467,9 +91510,9 @@ bAB
 aEP
 mPp
 wyj
-iBr
-hJd
-okK
+aAN
+ozL
+phW
 jtv
 tER
 nGG


### PR DESCRIPTION

## About The Pull Request

fixes #4916

Slightly changes the internal layout of the office, but mainly gets rid of a bunch of stacked wallmounts. Overall the office should look a good bit nicer (especially if you're a filthy observer).
## How does it improve TaleStation

That actually looks pretty decent now I think.

![image](https://github.com/TaleStation/TaleStation/assets/82386923/deb42315-2919-471f-a387-3ba01c489e86)
## Changelog
:cl:
qol: The pubbystation hop office is significantly less dreadful, especially for those who are unfortunate enough to be able to see both sides of the north wall.
/:cl:
