### PR TITLE
(Pubby & Lima) Cargo fixes and tweaks

### DIFF
--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -5861,7 +5861,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/left/directional/west{
 	name = "Cargo Desk";
-	req_access = list("mail_sorting")
+	req_access = list("shipping")
 	},
 /obj/machinery/door/firedoor,
 /obj/item/folder/yellow,
@@ -10657,7 +10657,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/left/directional/north{
 	name = "Delivery Desk";
-	req_access = list("mail_sorting")
+	req_access = list("shipping")
 	},
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/plating,
@@ -15019,8 +15019,7 @@
 /area/station/cargo/sorting)
 "fXF" = (
 /obj/machinery/door/airlock/external{
-	name = "Atmospherics External Airlock";
-	space_dir = null
+	name = "Atmospherics External Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -15410,8 +15409,7 @@
 "giM" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/window/preopen{
-	id = "SMESShutters";
-	id_tag = null
+	id = "SMESShutters"
 	},
 /turf/open/floor/plating,
 /area/station/engineering/engine_smes)
@@ -22714,9 +22712,7 @@
 /obj/item/stack/cable_coil,
 /obj/item/screwdriver,
 /obj/item/vending_refill/boozeomat,
-/obj/structure/closet/secure_closet/bar{
-	req_access = list("bar")
-	},
+/obj/structure/closet/secure_closet/bar,
 /obj/item/storage/box/beanbag,
 /obj/item/gun/ballistic/shotgun/doublebarrel,
 /turf/open/floor/mineral/plastitanium{
@@ -30937,8 +30933,7 @@
 /area/station/security/prison/mess)
 "maK" = (
 /obj/machinery/door/airlock/external{
-	name = "Engineering External Access";
-	space_dir = null
+	name = "Engineering External Access"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
@@ -38659,8 +38654,7 @@
 /area/station/maintenance/department/science)
 "oSD" = (
 /obj/machinery/door/airlock/external{
-	name = "Transit Tube External Access";
-	space_dir = null
+	name = "Transit Tube External Access"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -38855,8 +38849,7 @@
 "oVE" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/external{
-	name = "Solar Maintenance";
-	space_dir = null
+	name = "Solar Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/effect/decal/cleanable/dirt,
@@ -48484,11 +48477,14 @@
 /turf/open/floor/iron/dark,
 /area/station/science/cytology)
 "sxI" = (
-/obj/machinery/door/airlock/external{
-	name = "Supply Dock Airlock"
-	},
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
+/obj/machinery/door/airlock/external/glass{
+	name = "Supply Dock Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/storage)
 "sya" = (
@@ -49225,8 +49221,7 @@
 	dir = 1
 	},
 /obj/machinery/door/airlock/external{
-	name = "Atmospherics External Airlock";
-	space_dir = null
+	name = "Atmospherics External Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /turf/open/floor/iron/dark,
@@ -49837,8 +49832,7 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "sUK" = (
 /obj/machinery/door/airlock/external{
-	name = "Transit Tube External Access";
-	space_dir = null
+	name = "Transit Tube External Access"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -50621,7 +50615,7 @@
 	},
 /obj/machinery/door/window/left/directional/north{
 	name = "Cargo Disposal";
-	req_access = list("mail_sorting")
+	req_access = list("shipping")
 	},
 /turf/open/floor/plating,
 /area/station/cargo/sorting)
@@ -51270,8 +51264,7 @@
 /area/station/service/chapel/office)
 "txD" = (
 /obj/machinery/door/airlock/external{
-	name = "Solar Maintenance";
-	space_dir = null
+	name = "Solar Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -51667,8 +51660,7 @@
 /area/station/security/brig/upper)
 "tFG" = (
 /obj/machinery/door/airlock/external{
-	name = "Mining Dock Airlock";
-	space_dir = null
+	name = "Mining Dock Airlock"
 	},
 /obj/effect/turf_decal/loading_area{
 	dir = 4
@@ -53663,8 +53655,7 @@
 "utJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/window/preopen{
-	id = "SMESShutters";
-	id_tag = null
+	id = "SMESShutters"
 	},
 /turf/open/floor/plating,
 /area/station/engineering/main)
@@ -54165,8 +54156,7 @@
 /area/station/science/robotics/abandoned)
 "uFN" = (
 /obj/machinery/door/airlock/external{
-	name = "Atmospherics External Airlock";
-	space_dir = null
+	name = "Atmospherics External Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -54355,9 +54345,7 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "uJU" = (
-/obj/structure/musician/piano{
-	icon_state = "piano"
-	},
+/obj/structure/musician/piano,
 /obj/machinery/light/warm/directional/west,
 /obj/structure/cable,
 /turf/open/floor/carpet/black,
@@ -56070,11 +56058,13 @@
 /turf/open/openspace,
 /area/station/science/xenobiology)
 "vrt" = (
-/obj/machinery/door/airlock/external{
-	name = "Supply Dock Airlock";
-	space_dir = null
-	},
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
+/obj/machinery/door/airlock/external/glass{
+	name = "Supply Dock Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/storage)
 "vry" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -3316,7 +3316,7 @@
 	},
 /obj/machinery/door/window/left/directional/west{
 	name = "Deliveries Chute";
-	req_access = list("mail_sorting")
+	req_access = list("shipping")
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
@@ -11831,6 +11831,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/office)
+"dbr" = (
+/obj/machinery/door/airlock/external/glass{
+	name = "Supply Dock Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/cargo/storage)
 "dbG" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Armory Motion Sensor"
@@ -15275,7 +15285,7 @@
 	dir = 1;
 	name = "Returns";
 	pixel_y = 7;
-	req_access = list("mail_sorting")
+	req_access = list("shipping")
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
@@ -16430,14 +16440,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "ffO" = (
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/window/reinforced/spawner/directional/south,
 /obj/machinery/status_display/supply{
 	dir = 4;
 	layer = 4;
 	pixel_y = 32
 	},
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/station/cargo/storage)
 "fgc" = (
 /obj/machinery/door/firedoor/heavy,
@@ -18030,7 +18038,7 @@
 	},
 /obj/machinery/door/window/left/directional/west{
 	name = "Trash Chute";
-	req_access = list("mail_sorting")
+	req_access = list("shipping")
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
@@ -20573,7 +20581,7 @@
 /obj/machinery/button/door/directional/west{
 	id = "Disposal Exit";
 	name = "Disposal Vent Control";
-	req_access = list("mail_sorting");
+	req_access = list("shipping");
 	pixel_y = 6
 	},
 /turf/open/floor/iron,
@@ -22437,7 +22445,7 @@
 	},
 /obj/machinery/door/window/left/directional/west{
 	name = "Deliveries";
-	req_access = list("mail_sorting")
+	req_access = list("shipping")
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
@@ -27512,7 +27520,7 @@
 /obj/machinery/door/window/left/directional/west{
 	dir = 2;
 	name = "Cargo Desk";
-	req_access = list("mail_sorting")
+	req_access = list("shipping")
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
@@ -36980,7 +36988,7 @@
 	},
 /obj/machinery/door/window/right/directional/south{
 	name = "Cargo Desk";
-	req_access = list("mail_sorting")
+	req_access = list("shipping")
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
@@ -43320,12 +43328,14 @@
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "rJw" = (
-/obj/machinery/door/airlock/external{
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
+/obj/machinery/door/airlock/external/glass{
 	name = "Supply Dock Airlock"
 	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/any/supply/general,
-/turf/open/floor/iron,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plating,
 /area/station/cargo/storage)
 "rJF" = (
 /obj/structure/disposalpipe/segment{
@@ -49079,13 +49089,12 @@
 /turf/open/floor/iron,
 /area/station/science/research)
 "uwB" = (
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/machinery/camera/directional/east{
-	c_tag = "Cargo Docking Arm"
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
 	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "uwI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
@@ -56423,8 +56432,11 @@
 "xMv" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/window/reinforced/spawner/directional/west,
+/obj/machinery/camera/directional/east{
+	c_tag = "Cargo Docking Arm"
+	},
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "xMw" = (
 /obj/machinery/door/window/left/directional/west{
 	dir = 2;
@@ -101033,7 +101045,7 @@ tpC
 cDa
 mZS
 edj
-sAD
+uwB
 uAD
 oqh
 hYS
@@ -104372,9 +104384,9 @@ aYF
 mrz
 gQG
 aht
-uwB
-xmf
-gQG
+dUZ
+dbr
+dUZ
 aht
 aqG
 baG


### PR DESCRIPTION
## About The Pull Request

- Fixed all windoors that used `mail_sorting` access to use `shipping` instead, allowing them to be opened (Lima & Pubby)
- The cargo dock external airlocks on Pubby & Lima now use the glass variant, similar to other maps
- Minor edit to PubbyStation's cargo shuttle dock to add another airlock and remove the firelock. This prevents the fire alarm from tripping each time the shuttle departs. This is seen in the image below
- Added a fire alarm switch to Pubbystation's Cargo Bay. Also in the image below
- Added airlock cycling helpers to LimaStation's cargo dock
- SDMM automatically sanitized some redundant variables from LimaStation
![schmoovin](https://github.com/TaleStation/TaleStation/assets/105393050/1b4aed11-a9a6-4452-ad0b-baf4d4b2e3c4)

## How does it improve TaleStation

Improves the workflow of cargo workers, some areas now work as intended.

## Changelog
:cl:
fix: Cargo windoors on LimaStation and PubbyStation can now be operated.
add: The docking ports for the cargo supply shuttle on LimaStation and PubbyStation received some minor improvements.
/:cl: