### PR TITLE
[REMIRROR] Use typepaths for the quirk blacklist

### DIFF
--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -1,6 +1,41 @@
 #define EXP_ASSIGN_WAYFINDER 1200
 #define RANDOM_QUIRK_BONUS 3
 #define MINIMUM_RANDOM_QUIRKS 3
+
+// Shifted to glob so they are generated at world start instead of risking players doing preference stuff before the subsystem inits
+GLOBAL_LIST_INIT_TYPED(quirk_blacklist, /list/datum/quirk, list(
+	list(/datum/quirk/item_quirk/blindness, /datum/quirk/item_quirk/nearsighted),
+	list(/datum/quirk/jolly, /datum/quirk/depression, /datum/quirk/apathetic, /datum/quirk/hypersensitive),
+	list(/datum/quirk/no_taste, /datum/quirk/vegetarian, /datum/quirk/deviant_tastes, /datum/quirk/gamer),
+	list(/datum/quirk/pineapple_liker, /datum/quirk/pineapple_hater, /datum/quirk/gamer),
+	list(/datum/quirk/alcohol_tolerance, /datum/quirk/light_drinker),
+	list(/datum/quirk/item_quirk/clown_enjoyer, /datum/quirk/item_quirk/mime_fan, /datum/quirk/item_quirk/pride_pin),
+	list(/datum/quirk/bad_touch, /datum/quirk/friendly),
+	list(/datum/quirk/extrovert, /datum/quirk/introvert),
+	list(/datum/quirk/prosthetic_limb, /datum/quirk/quadruple_amputee, /datum/quirk/body_purist),
+	list(/datum/quirk/prosthetic_organ, /datum/quirk/tin_man, /datum/quirk/body_purist),
+	list(/datum/quirk/quadruple_amputee, /datum/quirk/paraplegic, /datum/quirk/hemiplegic),
+	list(/datum/quirk/quadruple_amputee, /datum/quirk/frail),
+	list(/datum/quirk/social_anxiety, /datum/quirk/mute),
+	list(/datum/quirk/mute, /datum/quirk/softspoken),
+	list(/datum/quirk/poor_aim, /datum/quirk/bighands),
+	list(/datum/quirk/bilingual, /datum/quirk/foreigner),
+	list(/datum/quirk/spacer_born, /datum/quirk/paraplegic, /datum/quirk/item_quirk/settler),
+	list(/datum/quirk/photophobia, /datum/quirk/nyctophobia),
+	list(/datum/quirk/item_quirk/settler, /datum/quirk/freerunning),
+))
+
+GLOBAL_LIST_INIT(quirk_string_blacklist, generate_quirk_string_blacklist())
+
+/proc/generate_quirk_string_blacklist()
+	var/list/string_blacklist = list()
+	for(var/blacklist in GLOB.quirk_blacklist)
+		var/list/string_list = list()
+		for(var/datum/quirk/typepath as anything in blacklist)
+			string_list += initial(typepath.name)
+		string_blacklist += list(string_list)
+	return string_blacklist
+
 //Used to process and handle roundstart quirks
 // - Quirk strings are used for faster checking in code
 // - Quirk datums are stored and hold different effects, as well as being a vector for applying trait string
@@ -15,29 +50,6 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 	var/list/quirk_points = list() //Assoc. list of quirk names and their "point cost"; positive numbers are good traits, and negative ones are bad
 	///An assoc list of quirks that can be obtained as a hardcore character, and their hardcore value.
 	var/list/hardcore_quirks = list()
-
-	/// A list of quirks that can not be used with each other. Format: list(quirk1,quirk2),list(quirk3,quirk4)
-	var/static/list/quirk_blacklist = list(
-		list("Blind", "Nearsighted"),
-		list("Jolly", "Depression", "Apathetic", "Hypersensitive"),
-		list("Ageusia", "Vegetarian", "Deviant Tastes", "Gamer"),
-		list("Ananas Affinity", "Ananas Aversion", "Gamer"),
-		list("Alcohol Tolerance", "Light Drinker"),
-		list("Clown Enjoyer", "Mime Fan", "Pride Pin"),
-		list("Bad Touch", "Friendly"),
-		list("Extrovert", "Introvert"),
-		list("Prosthetic Limb", "Quadruple Amputee", "Body Purist"),
-		list("Prosthetic Organ", "Tin Man", "Body Purist"),
-		list("Quadruple Amputee", "Paraplegic", "Hemiplegic"),
-		list("Quadruple Amputee", "Frail"),
-		list("Social Anxiety", "Mute"),
-		list("Mute", "Soft-Spoken"),
-		list("Stormtrooper Aim", "Big Hands"),
-		list("Bilingual", "Foreigner"),
-		list("Spacer", "Paraplegic", "Settler"),
-		list("Photophobia", "Nyctophobia"),
-		list("Settler", "Freerunning"),
-	)
 
 /datum/controller/subsystem/processing/quirks/Initialize()
 	get_quirks()
@@ -98,7 +110,7 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 	//Create a random list of stuff to start with
 	while(bonus_quirks > added_quirk_count)
 		var/quirk = pick(possible_quirks) //quirk is a string
-		if(quirk in quirk_blacklist) //prevent blacklisted
+		if(quirk in GLOB.quirk_blacklist) //prevent blacklisted
 			possible_quirks -= quirk
 			continue
 		if(quirk_points[quirk] > 0)
@@ -113,7 +125,7 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 		if(!length(possible_quirks))//Lets not get stuck
 			break
 		var/quirk = pick(quirks)
-		if(quirk in quirk_blacklist) //prevent blacklisted
+		if(quirk in GLOB.quirk_blacklist) //prevent blacklisted
 			possible_quirks -= quirk
 			continue
 		if(!quirk_points[quirk] < 0)//negative only
@@ -128,7 +140,7 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 		if(!length(possible_quirks))//Lets not get stuck
 			break
 		var/quirk = pick(quirks)
-		if(quirk in quirk_blacklist) //prevent blacklisted
+		if(quirk in GLOB.quirk_blacklist) //prevent blacklisted
 			possible_quirks -= quirk
 			continue
 		if(!quirk_points[quirk] > 0) //positive only
@@ -168,7 +180,7 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 
 		var/blacklisted = FALSE
 
-		for (var/list/blacklist as anything in quirk_blacklist)
+		for (var/list/blacklist as anything in GLOB.quirk_blacklist)
 			if (!(quirk in blacklist))
 				continue
 

--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -23,6 +23,13 @@ GLOBAL_LIST_INIT_TYPED(quirk_blacklist, /list/datum/quirk, list(
 	list(/datum/quirk/spacer_born, /datum/quirk/paraplegic, /datum/quirk/item_quirk/settler),
 	list(/datum/quirk/photophobia, /datum/quirk/nyctophobia),
 	list(/datum/quirk/item_quirk/settler, /datum/quirk/freerunning),
+	// NON-MODULAR CHANGES: Our unique quirk blacklist
+	list(/datum/quirk/allodynia, /datum/quirk/pain_vulnerability, /datum/quirk/pain_resistance, /datum/quirk/glass_jaw),
+	list(/datum/quirk/allodynia, /datum/quirk/bad_touch),
+	list(/datum/quirk/body_purist, /datum/quirk/prosthetic_limb/targeted/left_arm),
+	list(/datum/quirk/body_purist, /datum/quirk/prosthetic_limb/targeted/left_leg),
+	list(/datum/quirk/body_purist, /datum/quirk/prosthetic_limb/targeted/right_arm),
+	list(/datum/quirk/body_purist, /datum/quirk/prosthetic_limb/targeted/right_leg),
 ))
 
 GLOBAL_LIST_INIT(quirk_string_blacklist, generate_quirk_string_blacklist())

--- a/code/modules/client/preferences/middleware/quirks.dm
+++ b/code/modules/client/preferences/middleware/quirks.dm
@@ -43,7 +43,7 @@
 	return list(
 		"max_positive_quirks" = MAX_QUIRKS,
 		"quirk_info" = quirk_info,
-		"quirk_blacklist" = SSquirks.quirk_blacklist,
+		"quirk_blacklist" = GLOB.quirk_string_blacklist,
 	)
 
 /datum/preference_middleware/quirks/on_new_character(mob/user)

--- a/code/modules/mob/dead/new_player/preferences_setup.dm
+++ b/code/modules/mob/dead/new_player/preferences_setup.dm
@@ -55,7 +55,7 @@
 		var/datum/quirk/picked_quirk = pick(available_hardcore_quirks)
 
 		var/picked_quirk_blacklisted = FALSE
-		for(var/bl in SSquirks.quirk_blacklist) //Check if the quirk is blacklisted with our current quirks. quirk_blacklist is a list of lists.
+		for(var/bl in GLOB.quirk_blacklist) //Check if the quirk is blacklisted with our current quirks. quirk_blacklist is a list of lists.
 			var/list/blacklist = bl
 			if(!(picked_quirk in blacklist))
 				continue

--- a/talestation_modules/code/carbon_module/quirks/_quirk_blacklist.dm
+++ b/talestation_modules/code/carbon_module/quirks/_quirk_blacklist.dm
@@ -1,26 +1,17 @@
 /// -- Separate file to add in additional blacklists for modular quirks. --
 /datum/controller/subsystem/processing/quirks
-	/// Modular quirk blacklist. This is added into the master blacklist on Initialize.
-	var/static/list/module_blacklist = list(
-		list("Allodynia", "Hyperalgesia", "Hypoalgesia", "Glass Jaw"),
-		list("Allodynia", "Bad Touch"),
-		list("Body Purist", "Prosthetic Limb - Left Arm"),
-		list("Body Purist", "Prosthetic Limb - Left Leg"),
-		list("Body Purist", "Prosthetic Limb - Right Arm"),
-		list("Body Purist", "Prosthetic Limb - Right Leg"),
-	)
+
 	/// Species blacklist. Quirks cannot be added to species in the supplied list.
+	/* Doesn't work :(
+	* Needs to be made on /tg/ tho
 	var/static/list/species_blacklist = list(
 		"Light Drinker" = list(/datum/species/skrell),
 		"Night Vision" = list(/datum/species/tajaran),
 		"Frail" = list(/datum/species/avian),
 	)
+	*/
+
 	/// Species whitelist. Quirks can only be added to species in the supplied list.
 	var/static/list/species_whitelist = list(
 		//"Language - High Draconic" = list(/datum/species/lizard),
 	)
-
-//Extends the initialization proc, adding the module blacklists we have after the main init finishes.
-/datum/controller/subsystem/processing/quirks/Initialize(start_timeofday)
-	quirk_blacklist.Add(module_blacklist)
-	return ..()


### PR DESCRIPTION

Closes: #7413

## Changelog

:cl: spookydonut
fix: Incompatible quirks in existing savefiles shouldn't be possible anymore.
/:cl:

