### PR TITLE
Maps, sprites and lore teams are now code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,7 @@
 
 #Lore
 /talestation_modules/code/species_module/ @talestation/lore-curators
-talestation_modules/icons/species/ @talestation/lore-curators
+/talestation_modules/icons/species/ @talestation/lore-curators
 
 #Maps
 /_maps/ @talestation/Maptainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,8 +7,8 @@
 #Org Teams
 
 #Lore
-/talestation_modules/code/species_module/ @talestation/Lore-Curators
-talestation_modules/icons/species/ @talestation/Lore-Curators
+/talestation_modules/code/species_module/ @talestation/lore-curators
+talestation_modules/icons/species/ @talestation/lore-curators
 
 #Maps
 /_maps/ @talestation/Maptainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,10 +4,22 @@
 # In the event that multiple org members are to be informed of changes
 # to the same file or dir, add them to the end under Multiple Owners
 
+#Org Teams
+
+#Lore
+/talestation_modules/code/species_module/ @talestation/Lore-Curators
+talestation_modules/icons/species/ @talestation/Lore-Curators
+
+#Maps
+/_maps/ @talestation/Maptainers
+
+#Icons
+/talestation_modules/icons/ @talestation/Spritetainers
+
 #Jolly66
 
 #Tajaran
-/talestation_modules/code/species_module/tajaran @Jolly-66
+/talestation_modules/code/species_module/tajaran/ @Jolly-66
 
 #XenoBotany
 /code/modules/hydroponics/seed_extractor.dm @Jolly-66
@@ -16,15 +28,9 @@
 #prodirus
 
 #Pain
-/talestation_modules/code/pain_module @prodirus
+/talestation_modules/code/pain_module/ @prodirus
 
 #Multiple Owners
 
 #Config
 /config/ @Jolly-66 @MarkSuckerberg
-
-#Maps
-/_maps/ @Jolly-66
-
-#Icons
-/talestation_modules/icons @Onule

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,8 +7,8 @@
 #Org Teams
 
 #Lore
-/talestation_modules/code/species_module/ @talestation/lore-curators
-/talestation_modules/icons/species/ @talestation/lore-curators
+/talestation_modules/code/species_module/ @talestation/Loretainers
+/talestation_modules/icons/species/ @talestation/Loretainers
 
 #Maps
 /_maps/ @talestation/Maptainers


### PR DESCRIPTION
The lore team didn't contest me on this, and since I was there, I updated maps and sprites to include the teams. Woohoo!