### PR TITLE
Removes TWO maintenance spawners from Pubby's asteroid bomb testing site

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -9769,10 +9769,6 @@
 /obj/item/toy/figure/chaplain,
 /turf/open/floor/plating/airless,
 /area/space)
-"cls" = (
-/obj/effect/spawner/random/maintenance,
-/turf/closed/mineral,
-/area/centcom/asteroid/nearstation/bomb_site)
 "clv" = (
 /turf/closed/mineral/iron,
 /area/centcom/asteroid/nearstation/bomb_site)
@@ -9791,10 +9787,6 @@
 /obj/structure/weightmachine,
 /turf/open/floor/iron,
 /area/station/security/prison)
-"clF" = (
-/obj/effect/spawner/random/maintenance,
-/turf/closed/mineral/random/low_chance,
-/area/centcom/asteroid/nearstation/bomb_site)
 "clG" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -99953,7 +99945,7 @@ ckK
 ckK
 ckK
 ckK
-clF
+ckK
 cju
 cju
 ckK
@@ -103799,7 +103791,7 @@ cju
 cju
 ckK
 ckK
-cls
+cju
 ckK
 ckK
 cju


### PR DESCRIPTION
Fixes: #8536

![image](https://github.com/TaleStation/TaleStation/assets/70232195/f900b2bf-0e44-4f8e-bb2a-a3e1e94a7872)


## Changelog

:cl: Jolly
fix: [PubbyStation] Two maintenance spawners should no lonnger spawn in the bomb testing site asteroid.
/:cl:
