### PR TITLE
Mapping - Updates, tweaks, and maintenance

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -3488,9 +3488,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "bhL" = (
-/obj/machinery/byteforge,
-/turf/open/space/basic,
-/area/space)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "bhR" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining{
@@ -4268,6 +4275,8 @@
 "bvR" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/north,
+/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "bwc" = (
@@ -5783,8 +5792,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /obj/machinery/airalarm/directional/south,
 /obj/effect/mapping_helpers/airalarm/engine_access,
+/obj/effect/mapping_helpers/airalarm/link{
+	chamber_id = "engine"
+	},
+/obj/effect/mapping_helpers/airalarm/tlv_no_checks,
 /turf/open/floor/engine,
-/area/station/engineering/supermatter)
+/area/station/engineering/supermatter/room)
 "bZQ" = (
 /obj/structure/railing{
 	dir = 8
@@ -6331,8 +6344,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/iron/recharge_floor,
-/area/station/maintenance/port/aft)
+/obj/machinery/mech_bay_recharge_port{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron,
+/area/station/security/mechbay)
 "chc" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/emcloset,
@@ -6421,8 +6438,7 @@
 /obj/structure/chair/stool/bar/directional/west,
 /mob/living/basic/trooper/russian{
 	environment_smash = 0;
-	loot = list(/obj/effect/mob_spawn/corpse/human/russian);
-	name = "Russian Mobster"
+	loot = list(/obj/effect/mob_spawn/corpse/human/russian)
 	},
 /turf/open/floor/wood,
 /area/station/maintenance/port/greater)
@@ -7930,10 +7946,13 @@
 /turf/open/floor/engine,
 /area/station/ai_monitored/turret_protected/ai)
 "cIg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/contraband/random/directional/east,
+/obj/structure/sign/poster/official/random/directional/east,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/light/directional/east,
 /turf/open/floor/plating,
-/area/station/maintenance/port/aft)
+/area/station/security/mechbay)
 "cIk" = (
 /obj/machinery/disposal/bin,
 /obj/machinery/firealarm/directional/north,
@@ -13048,8 +13067,12 @@
 /obj/machinery/airalarm/directional/south,
 /obj/effect/mapping_helpers/airalarm/mixingchamber_access,
 /obj/effect/turf_decal/tile/purple/half/contrasted,
+/obj/effect/mapping_helpers/airalarm/tlv_no_checks,
+/obj/effect/mapping_helpers/airalarm/link{
+	chamber_id = "ordnancefreezer"
+	},
 /turf/open/floor/iron/showroomfloor,
-/area/station/science/ordnance/freezerchamber)
+/area/station/science/ordnance)
 "erH" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron/dark,
@@ -13595,9 +13618,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/blood/old,
-/mob/living/basic/goat/pete{
-	name = "Pete"
-	},
+/mob/living/basic/goat/pete,
 /turf/open/floor/iron/freezer,
 /area/station/service/kitchen/coldroom)
 "eBx" = (
@@ -15437,11 +15458,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/effect/landmark/generic_maintenance_landmark,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/station/maintenance/port/aft)
+/area/station/security/mechbay)
 "fhY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -18699,6 +18718,9 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
+"gfa" = (
+/turf/closed/wall/rust,
+/area/station/security/mechbay)
 "gfc" = (
 /obj/structure/filingcabinet,
 /obj/effect/turf_decal/bot_white,
@@ -21584,8 +21606,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/port/aft)
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron,
+/area/station/security/mechbay)
 "hda" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -22301,8 +22324,12 @@
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/airalarm/link{
+	chamber_id = "ordnanceburn"
+	},
+/obj/effect/mapping_helpers/airalarm/tlv_no_checks,
 /turf/open/floor/iron/showroomfloor,
-/area/station/science/ordnance/burnchamber)
+/area/station/science/ordnance)
 "hnl" = (
 /obj/machinery/door/window/left/directional/north{
 	dir = 2;
@@ -27832,11 +27859,11 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters{
 	dir = 8;
-	id = "sparemech";
-	name = "Abandoned Mech Bay"
+	id = "secmech";
+	name = "Security Mech Bay"
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/port/aft)
+/area/station/security/mechbay)
 "iTq" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -29042,11 +29069,11 @@
 	dir = 1
 	},
 /obj/machinery/button/door/directional/west{
-	id = "sparemech";
-	name = "Abandoned Mech Bay Toggle"
+	id = "secmech";
+	name = "Mech Bay Window Shutters Control"
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/port/aft)
+/area/station/security/mechbay)
 "jkB" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 9
@@ -30153,8 +30180,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /mob/living/basic/trooper/russian{
 	environment_smash = 0;
-	loot = list(/obj/effect/mob_spawn/corpse/human/russian);
-	name = "Russian Mobster"
+	loot = list(/obj/effect/mob_spawn/corpse/human/russian)
 	},
 /turf/open/floor/carpet/green,
 /area/station/maintenance/port/greater)
@@ -32199,8 +32225,7 @@
 /obj/effect/landmark/event_spawn,
 /mob/living/basic/trooper/russian{
 	environment_smash = 0;
-	loot = list(/obj/effect/mob_spawn/corpse/human/russian);
-	name = "Russian Mobster"
+	loot = list(/obj/effect/mob_spawn/corpse/human/russian)
 	},
 /turf/open/floor/carpet/green,
 /area/station/maintenance/port/greater)
@@ -33932,12 +33957,16 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/fore)
 "kWW" = (
-/obj/structure/barricade/wooden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/abandoned,
-/obj/effect/spawner/structure/electrified_grille,
-/obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
+/obj/machinery/door/airlock/security{
+	name = "Mech Bay"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "sec-maint-passthrough"
+	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/aft)
 "kXp" = (
@@ -34040,13 +34069,13 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "kYI" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/office{
 	dir = 8
 	},
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/port/aft)
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron,
+/area/station/security/mechbay)
 "kYP" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/blood/drip{
@@ -37423,6 +37452,7 @@
 	dir = 6
 	},
 /obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "mfd" = (
@@ -37672,6 +37702,9 @@
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/unres,
 /obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "sec-maint-passthrough"
+	},
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/aft)
 "mis" = (
@@ -42312,9 +42345,18 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "nMD" = (
-/obj/structure/girder/displaced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "sec-maint-passthrough"
+	},
+/turf/open/floor/iron/dark,
 /area/station/maintenance/port/aft)
 "nMQ" = (
 /obj/structure/disposalpipe/segment,
@@ -44074,15 +44116,13 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/funeral)
 "ovm" = (
-/obj/machinery/mech_bay_recharge_port{
-	dir = 2
-	},
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/port/aft)
+/obj/vehicle/sealed/mecha/ripley/paddy/preset,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/recharge_floor,
+/area/station/security/mechbay)
 "ovo" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -51090,11 +51130,11 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/aft)
 "qRD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/broken_flooring/side/directional/east,
+/obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
-/area/station/maintenance/port/aft)
+/area/station/security/mechbay)
 "qRK" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
@@ -53418,8 +53458,11 @@
 /obj/structure/rack,
 /obj/item/storage/toolbox/emergency,
 /obj/item/stack/rods/ten,
+/obj/machinery/camera/directional/south{
+	c_tag = "Security Mech Bay"
+	},
 /turf/open/floor/plating,
-/area/station/maintenance/port/aft)
+/area/station/security/mechbay)
 "rBj" = (
 /obj/structure/transit_tube/curved/flipped,
 /turf/open/space/basic,
@@ -55213,10 +55256,10 @@
 /turf/open/floor/engine,
 /area/station/engineering/storage/tech)
 "seW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/firecloset,
-/obj/effect/turf_decal/bot,
-/obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "sfi" = (
@@ -58852,7 +58895,6 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/structure/sign/warning/electric_shock/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor/plating,
@@ -60147,6 +60189,10 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/lesser)
+"tIO" = (
+/obj/machinery/air_sensor/engine_chamber,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter)
 "tJa" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Atmospherics Tank - N2O";
@@ -60705,10 +60751,11 @@
 /area/station/security/execution/education)
 "tSP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
-/area/station/maintenance/port/aft)
+/area/station/security/mechbay)
 "tSY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -61187,12 +61234,11 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/medbay/central)
 "ubC" = (
-/obj/structure/grille,
-/obj/structure/barricade/wooden,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/abandoned,
-/obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
-/turf/open/floor/iron/dark,
+/obj/machinery/door/poddoor/shutters{
+	id = "secmechbay";
+	name = "Security Mech Bay Shutters"
+	},
+/turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "ubF" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -61368,11 +61414,16 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "uey" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/structure/crate,
+/obj/structure/reagent_dispensers/fueltank,
 /obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/button/door/directional/north{
+	id = "secmechbay";
+	name = "Security Mech Garage Door Controls";
+	req_access = list("security")
+	},
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/plating,
-/area/station/maintenance/port/aft)
+/area/station/security/mechbay)
 "ueJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -62565,14 +62616,12 @@
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "uwp" = (
-/obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/unres,
-/obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
-/turf/open/floor/iron/dark,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "uwq" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer2{
@@ -64471,6 +64520,7 @@
 "vek" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "ves" = (
@@ -65372,6 +65422,9 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"vuf" = (
+/turf/closed/wall,
+/area/station/security/mechbay)
 "vuj" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -66851,6 +66904,12 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space)
+"vOk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/sign/warning/directional/west,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "vOl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -70136,10 +70195,13 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/structure/sign/warning/electric_shock/directional/south,
-/obj/structure/grille,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/button/door/directional/south{
+	id = "secmechbay";
+	name = "Security Mech Garage Door Controls";
+	req_access = list("security")
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "wNo" = (
@@ -74074,9 +74136,6 @@
 "ycs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/maintenance{
-	name = "Security Maintenance"
-	},
 /obj/structure/sign/directions/evac{
 	pixel_y = -24
 	},
@@ -74085,6 +74144,12 @@
 	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/door/airlock/security{
+	name = "Mech Bay"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "sec-maint-passthrough"
+	},
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/aft)
 "ycx" = (
@@ -77715,7 +77780,7 @@ aaa
 aaa
 aaa
 aaa
-bhL
+aaa
 aaa
 aaa
 aaa
@@ -89742,8 +89807,8 @@ gPA
 iTj
 iTj
 iTj
-tCU
-tCU
+vuf
+vuf
 uUS
 lsu
 sWl
@@ -90000,7 +90065,7 @@ ovm
 cgU
 hcP
 jks
-gPA
+gfa
 lPX
 fjw
 jHR
@@ -90257,7 +90322,7 @@ qRD
 fhL
 kYI
 rBd
-tCU
+vuf
 eGW
 mui
 uJg
@@ -90510,11 +90575,11 @@ qKI
 qJR
 wNf
 tCU
-tCU
+uey
 tSP
 cIg
-gPA
-tCU
+gfa
+vuf
 ftX
 xlk
 cpC
@@ -90766,7 +90831,7 @@ cuR
 cuR
 cuR
 eEh
-nMD
+gPA
 tCU
 kWW
 tCU
@@ -91021,11 +91086,11 @@ cuR
 qJR
 qJR
 iVH
-seW
+qJR
 mgn
-bIR
+vOk
 tmp
-bzo
+bhL
 eTG
 mij
 pFl
@@ -91278,12 +91343,12 @@ tbs
 rhy
 uwp
 hKE
-iBi
+nMD
 fnL
 iBi
 hlS
-tSP
-uey
+seW
+bIR
 mWV
 vek
 kJs
@@ -110314,7 +110379,7 @@ uqD
 kBz
 vyN
 mda
-vyN
+tIO
 dGG
 vyN
 eVL

--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -804,6 +804,10 @@
 	pixel_y = 4
 	},
 /obj/item/pen,
+/obj/structure/desk_bell{
+	pixel_y = 8;
+	pixel_x = -8
+	},
 /turf/open/floor/plating,
 /area/station/science/lab)
 "asE" = (
@@ -911,6 +915,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
+"avs" = (
+/obj/structure/table,
+/obj/structure/desk_bell{
+	pixel_y = 9;
+	pixel_x = 8
+	},
+/turf/open/floor/mineral/plastitanium{
+	name = "black plastitanium floor"
+	},
+/area/station/service/bar)
 "avu" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -3393,6 +3407,19 @@
 /obj/item/assembly/flash/handheld,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
+"bxm" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/structure/sign/warning/pods{
+	pixel_y = 30
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark/smooth_edge,
+/area/station/security/brig/upper)
 "bxv" = (
 /obj/structure/chair{
 	dir = 1
@@ -5872,6 +5899,10 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/item/folder/yellow,
+/obj/structure/desk_bell{
+	pixel_y = 7;
+	pixel_x = 7
+	},
 /turf/open/floor/plating,
 /area/station/cargo/office)
 "cwB" = (
@@ -6285,6 +6316,7 @@
 /area/station/maintenance/department/chapel)
 "cFO" = (
 /obj/structure/cable,
+/mob/living/basic/bot/medbot/autopatrol,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "cFR" = (
@@ -6733,6 +6765,16 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
+"cQR" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/dark/smooth_edge,
+/area/station/security/brig/upper)
 "cQS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -8017,6 +8059,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
+"doa" = (
+/obj/structure/table,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "Serving Hatch"
+	},
+/obj/structure/desk_bell,
+/turf/open/floor/iron,
+/area/station/service/kitchen)
 "doc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -8126,10 +8178,12 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/firealarm/directional/north,
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
+	},
+/obj/machinery/computer/security/telescreen/prison{
+	pixel_y = 30
 	},
 /turf/open/floor/iron/dark/smooth_edge,
 /area/station/security/brig/upper)
@@ -8501,22 +8555,8 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "dys" = (
-/obj/machinery/computer/security/telescreen/prison{
-	pixel_y = 30
-	},
-/obj/structure/cable,
-/obj/machinery/camera{
-	c_tag = "Security - Fore Hallway";
-	dir = 9;
-	network = list("ss13","prison")
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/smooth_edge,
-/area/station/security/brig/upper)
+/turf/closed/wall/r_wall,
+/area/station/security/mechbay)
 "dyu" = (
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/medical)
@@ -10066,8 +10106,12 @@
 	},
 /obj/machinery/airalarm/directional/east,
 /obj/effect/mapping_helpers/airalarm/engine_access,
+/obj/effect/mapping_helpers/airalarm/tlv_no_checks,
+/obj/effect/mapping_helpers/airalarm/link{
+	chamber_id = "engine"
+	},
 /turf/open/floor/engine,
-/area/station/engineering/supermatter)
+/area/station/engineering/supermatter/room)
 "ejm" = (
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
@@ -12853,8 +12897,12 @@
 /obj/machinery/airalarm/directional/south,
 /obj/effect/mapping_helpers/airalarm/mixingchamber_access,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/airalarm/link{
+	chamber_id = "ordnancefreezer"
+	},
+/obj/effect/mapping_helpers/airalarm/tlv_no_checks,
 /turf/open/floor/iron,
-/area/station/science/ordnance/freezerchamber)
+/area/station/science/ordnance)
 "fjJ" = (
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /obj/machinery/light/directional/east,
@@ -13211,6 +13259,10 @@
 	},
 /obj/item/reagent_containers/cup/bucket,
 /obj/structure/table/reinforced,
+/obj/structure/desk_bell{
+	pixel_y = 9;
+	pixel_x = 8
+	},
 /turf/open/floor/plating,
 /area/station/service/hydroponics)
 "fqy" = (
@@ -13226,10 +13278,6 @@
 /obj/item/stock_parts/cell/high{
 	pixel_y = 5
 	},
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/item/stock_parts/cell/high{
 	pixel_y = 2
 	},
@@ -13240,6 +13288,7 @@
 	pixel_x = 9
 	},
 /obj/machinery/light/directional/east,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
 "fqH" = (
@@ -18604,8 +18653,7 @@
 /obj/machinery/duct,
 /obj/structure/cable,
 /mob/living/basic/goat/pete{
-	desc = "The chefs most 'trusted' pet Goat. Just don't stare at him too long.";
-	name = "Pete"
+	desc = "The chefs most 'trusted' pet Goat. Just don't stare at him too long."
 	},
 /turf/open/floor/iron/freezer,
 /area/station/service/kitchen/coldroom)
@@ -20187,6 +20235,18 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"hYN" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light_switch/directional/west,
+/turf/open/floor/iron/dark/textured,
+/area/station/security/mechbay)
 "hYO" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -21510,6 +21570,11 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
+"iBm" = (
+/obj/machinery/computer/mech_bay_power_console,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron,
+/area/station/security/mechbay)
 "iBz" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Dormitory"
@@ -25390,13 +25455,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "jZr" = (
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
 /obj/machinery/camera{
 	c_tag = "Command - Teleporter";
 	dir = 9
 	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/station/command/teleporter)
 "jZu" = (
@@ -26223,6 +26286,13 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage)
+"knj" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 1
+	},
+/area/station/security/brig/upper)
 "kns" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -27459,6 +27529,10 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/machinery/door/firedoor,
+/obj/structure/desk_bell{
+	pixel_y = 8;
+	pixel_x = 8
+	},
 /turf/open/floor/plating,
 /area/station/engineering/lobby)
 "kMz" = (
@@ -31009,9 +31083,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "mbB" = (
-/obj/machinery/incident_display/delam/directional/west,
-/turf/open/floor/iron/smooth,
-/area/station/engineering/main)
+/obj/machinery/door/poddoor/shutters{
+	id = "secmechbay";
+	name = "Security Mech Bay Shutters"
+	},
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/effect/turf_decal/box,
+/turf/open/floor/iron/dark/textured_large,
+/area/station/security/mechbay)
 "mbG" = (
 /obj/machinery/barsign,
 /turf/closed/wall,
@@ -32456,6 +32535,10 @@
 /obj/structure/flora/bush/flowers_br/style_random,
 /turf/open/floor/grass,
 /area/station/command/bridge)
+"mCb" = (
+/obj/machinery/air_sensor/engine_chamber,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter)
 "mCd" = (
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
@@ -32576,6 +32659,25 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
+"mFB" = (
+/obj/machinery/button/door/directional/south{
+	id = "secmechbay";
+	name = "Security Mech Garage Door Controls";
+	req_access = list("security")
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/machinery/camera/directional/east{
+	c_tag = "Security - Mech Bay"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/security/mechbay)
 "mFG" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -32913,6 +33015,10 @@
 /obj/item/pen,
 /obj/item/crowbar,
 /obj/effect/landmark/navigate_destination,
+/obj/structure/desk_bell{
+	pixel_y = 8;
+	pixel_x = -8
+	},
 /turf/open/floor/plating,
 /area/station/science/robotics/lab)
 "mMR" = (
@@ -34244,8 +34350,12 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 5
 	},
+/obj/effect/mapping_helpers/airalarm/tlv_no_checks,
+/obj/effect/mapping_helpers/airalarm/link{
+	chamber_id = "ordnanceburn"
+	},
 /turf/open/floor/iron,
-/area/station/science/ordnance/burnchamber)
+/area/station/science/ordnance)
 "nlE" = (
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
@@ -35928,6 +36038,10 @@
 /obj/machinery/telecomms/hub/preset,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
+"nPY" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/station/security/mechbay)
 "nQu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -37688,6 +37802,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/structure/desk_bell{
+	pixel_x = -9;
+	pixel_y = 10
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "ozr" = (
@@ -39146,11 +39264,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "pbv" = (
-/obj/structure/sign/warning/electric_shock{
-	pixel_y = -30
+/obj/machinery/mech_bay_recharge_port{
+	dir = 2
 	},
-/turf/open/space/openspace,
-/area/space)
+/turf/open/floor/iron,
+/area/station/security/mechbay)
 "pby" = (
 /obj/structure/table,
 /obj/machinery/cell_charger{
@@ -41464,6 +41582,7 @@
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/stripes/box,
 /obj/structure/disposalpipe/trunk,
+/obj/machinery/incident_display/delam/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage)
 "pUK" = (
@@ -46613,6 +46732,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine/atmos)
+"rPr" = (
+/obj/machinery/door/airlock/security{
+	name = "Mech Bay"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/security/brig,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/textured,
+/area/station/security/mechbay)
 "rPC" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light/directional/north,
@@ -46642,6 +46771,14 @@
 	dir = 8
 	},
 /area/station/security/brig)
+"rQe" = (
+/obj/structure/table/reinforced,
+/obj/item/weldingtool,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/machinery/airalarm/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/security/mechbay)
 "rQp" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible,
 /turf/closed/wall/r_wall,
@@ -48701,10 +48838,18 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/extinguisher_cabinet/directional/north,
-/obj/machinery/newscaster/directional/north,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Security - Fore Hallway";
+	dir = 9;
+	network = list("ss13","prison")
+	},
+/obj/machinery/button/door/directional/north{
+	id = "secmechbay";
+	name = "Security Mech Garage Door Controls";
+	req_access = list("security")
 	},
 /turf/open/floor/iron/dark/smooth_edge,
 /area/station/security/brig/upper)
@@ -50315,17 +50460,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "tdI" = (
-/obj/machinery/requests_console{
-	department = "Security";
-	name = "Security RC";
-	pixel_y = 30
-	},
-/obj/effect/mapping_helpers/requests_console/information,
-/obj/effect/mapping_helpers/requests_console/assistance,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/smooth_edge,
@@ -54235,6 +54373,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "uGU" = (
@@ -55432,6 +55571,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/landmark/start/hangover,
 /obj/structure/cable,
+/obj/structure/desk_bell,
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/hop)
 "veU" = (
@@ -57393,7 +57533,6 @@
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "vUe" = (
-/obj/item/radio/intercom/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/vending/wardrobe/engi_wardrobe,
@@ -57511,18 +57650,9 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "vXB" = (
-/obj/machinery/light/directional/north,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/sign/warning/pods{
-	pixel_y = 30
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/smooth_edge,
-/area/station/security/brig/upper)
+/obj/vehicle/sealed/mecha/ripley/paddy/preset,
+/turf/open/floor/iron/recharge_floor,
+/area/station/security/mechbay)
 "vXC" = (
 /obj/machinery/light_switch/directional/east{
 	pixel_x = 22;
@@ -59756,6 +59886,15 @@
 /obj/structure/tank_holder/extinguisher,
 /turf/open/floor/plating,
 /area/station/maintenance/department/chapel)
+"wQt" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/red/filled/warning,
+/turf/open/floor/iron/dark/textured,
+/area/station/security/mechbay)
 "wQD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -143970,7 +144109,7 @@ oeJ
 uyd
 mzS
 wjx
-lWm
+mCb
 cTc
 uuk
 hWJ
@@ -145462,7 +145601,7 @@ dDw
 nHP
 dOJ
 rUY
-ugr
+cQR
 jrb
 wHR
 pML
@@ -146743,12 +146882,12 @@ bKY
 aEA
 uLj
 iTE
-qQm
-qQm
-qQm
-qQm
+dys
+dys
+dys
+dys
 hxY
-jrb
+knj
 tHg
 qUf
 lml
@@ -147000,11 +147139,11 @@ ghn
 ghn
 ghn
 ulT
-qQm
-xzK
-xzK
-qQm
 dys
+rQe
+hYN
+rPr
+ugr
 jrb
 wHR
 reO
@@ -147256,11 +147395,11 @@ xzK
 xzK
 xzK
 xzK
-xzK
-xzK
-xzK
-xzK
-qQm
+dys
+iBm
+nPY
+wQt
+mbB
 tdI
 jrb
 wHR
@@ -147309,7 +147448,7 @@ eJn
 fyy
 kKB
 qDS
-mbB
+pwV
 pwV
 nJI
 dxq
@@ -147508,16 +147647,16 @@ xzK
 xzK
 xzK
 xzK
-bYt
-cDb
-cGJ
-cGJ
-cGJ
-qQm
-qQm
-qQm
-qQm
-qQm
+ymg
+ymg
+ymg
+ymg
+ymg
+dys
+pbv
+vXB
+mFB
+dys
 sBy
 rya
 wHR
@@ -147766,15 +147905,15 @@ xzK
 xzK
 xzK
 bYt
-xzK
-xzK
-xzK
-xzK
-lXn
-qQm
-dxE
-kNp
-qQm
+cDb
+cGJ
+cGJ
+cGJ
+dys
+dys
+dys
+dys
+dys
 woI
 oZn
 tHg
@@ -148023,16 +148162,16 @@ xzK
 xzK
 xzK
 bYt
-sjY
 xzK
 xzK
 xzK
-diG
-gAl
-oRW
-bgm
-nBg
-ugr
+xzK
+lXn
+qQm
+dxE
+kNp
+qQm
+bxm
 cNa
 kih
 vRW
@@ -148280,16 +148419,16 @@ xzK
 xzK
 xzK
 bYt
+sjY
 xzK
 xzK
 xzK
-xzK
-lXn
-qQm
-qCj
-uqm
-qQm
-vXB
+diG
+gAl
+oRW
+bgm
+nBg
+ugr
 spX
 aGH
 tBm
@@ -148537,14 +148676,14 @@ xzK
 xzK
 xzK
 bYt
-cDb
-cGJ
-cGJ
-cGJ
+xzK
+xzK
+xzK
+xzK
+lXn
 qQm
-qQm
-qQm
-qQm
+qCj
+uqm
 qQm
 iCv
 nSY
@@ -148793,15 +148932,15 @@ xzK
 xzK
 xzK
 xzK
-xzK
-xzK
-xzK
-xzK
-xzK
-xzK
-xzK
-xzK
-pbv
+bYt
+cDb
+cGJ
+cGJ
+cGJ
+qQm
+qQm
+qQm
+qQm
 whK
 evn
 khQ
@@ -159641,7 +159780,7 @@ hbV
 rUI
 iHJ
 wrH
-rcc
+avs
 odT
 iHk
 iHk
@@ -160646,7 +160785,7 @@ vjk
 qvO
 gMe
 gHk
-qeX
+doa
 qeX
 qeX
 qeX

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -813,8 +813,10 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
 "aiR" = (
-/turf/closed/wall,
-/area/station/command/heads_quarters/hos)
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/security/mechbay)
 "aiS" = (
 /turf/closed/wall,
 /area/station/maintenance/department/crew_quarters/dorms)
@@ -4485,9 +4487,7 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/kitchen/coldroom)
 "aUZ" = (
-/mob/living/basic/goat/pete{
-	name = "Pete"
-	},
+/mob/living/basic/goat/pete,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/kitchen/coldroom)
@@ -9585,6 +9585,7 @@
 /area/station/service/chapel/monastery)
 "cit" = (
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/air_sensor/engine_chamber,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "ciF" = (
@@ -9654,10 +9655,14 @@
 /turf/open/misc/asteroid/airless,
 /area/centcom/asteroid/nearstation/bomb_site)
 "cjN" = (
-/obj/structure/extinguisher_cabinet/directional/east,
-/obj/machinery/light/directional/south,
-/obj/structure/tank_dispenser/oxygen,
-/obj/effect/turf_decal/bot,
+/obj/machinery/button/door/directional/east{
+	name = "Security Mech Garage Door Controls";
+	id = "secmechbay";
+	req_access = list("security")
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/lockers)
 "cjQ" = (
@@ -11036,6 +11041,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"cHE" = (
+/obj/machinery/computer/mech_bay_power_console{
+	dir = 1
+	},
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/iron,
+/area/station/security/mechbay)
 "cHS" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Firing Range"
@@ -11117,6 +11129,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
+"cKt" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron,
+/area/station/security/mechbay)
 "cKu" = (
 /obj/machinery/light/small/directional/east,
 /obj/effect/decal/cleanable/dirt,
@@ -11768,6 +11784,10 @@
 /area/station/cargo/warehouse/upper)
 "cYV" = (
 /obj/structure/punching_bag,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/lockers)
 "cZa" = (
@@ -12186,6 +12206,19 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/station/security/execution/transfer)
+"diu" = (
+/obj/machinery/door/poddoor/shutters{
+	dir = 8;
+	id = "secmechbay";
+	name = "Security Mech Bay Shutters"
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/caution/stand_clear{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/mechbay)
 "diD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -14739,11 +14772,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "eqC" = (
-/obj/structure/sign/directions/evac{
-	dir = 1;
-	pixel_x = 32;
-	pixel_y = -8
-	},
 /obj/structure/sign/directions/security{
 	dir = 1;
 	pixel_x = 32;
@@ -14752,6 +14780,10 @@
 /obj/structure/sign/directions/command{
 	dir = 1;
 	pixel_x = 32
+	},
+/obj/structure/sign/directions/evac/directional/east{
+	pixel_y = -8;
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
@@ -15113,6 +15145,13 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/lockers)
+"eAh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/mechbay)
 "eAj" = (
 /obj/item/flashlight/lantern,
 /turf/open/floor/iron/dark,
@@ -15265,6 +15304,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
+"eDF" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/station/security/lockers)
 "eDX" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/computer/security/telescreen{
@@ -15651,6 +15697,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"eLW" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron,
+/area/station/security/mechbay)
 "eMq" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -15669,7 +15719,12 @@
 /turf/open/floor/iron/dark,
 /area/station/science/robotics)
 "eMv" = (
-/obj/item/radio/intercom/directional/east,
+/obj/effect/mapping_helpers/requests_console/assistance,
+/obj/effect/mapping_helpers/requests_console/information,
+/obj/machinery/requests_console/directional/south{
+	name = "Security Lockers Requests Console";
+	department = "Security"
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/lockers)
 "eMM" = (
@@ -16043,6 +16098,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer2,
 /turf/open/space,
 /area/space/nearstation)
+"eUt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/station/security/lockers)
 "eUE" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal/delivery_chute{
@@ -16249,6 +16311,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
+"faU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/mechbay)
 "faY" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -18984,6 +19056,7 @@
 "gsa" = (
 /obj/machinery/recharge_station,
 /obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/lockers)
 "gsA" = (
@@ -19425,8 +19498,12 @@
 /obj/machinery/computer/atmos_control/ordnancemix{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/airalarm/link{
+	chamber_id = "ordnanceburn"
+	},
+/obj/effect/mapping_helpers/airalarm/tlv_no_checks,
 /turf/open/floor/iron/white,
-/area/station/science/ordnance/burnchamber)
+/area/station/science/ordnance)
 "gAY" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -20498,7 +20575,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "hau" = (
@@ -22337,8 +22415,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/door/window/left/directional/west{
-	dir = 1;
+/obj/machinery/door/window/left/directional/north{
 	name = "Atmospherics Delivery";
 	req_access = list("atmospherics")
 	},
@@ -23289,6 +23366,9 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"iwa" = (
+/turf/open/floor/iron/dark,
+/area/station/security/mechbay)
 "iwl" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -23592,6 +23672,14 @@
 	},
 /turf/open/floor/plating,
 /area/station/security/execution/transfer)
+"iDL" = (
+/obj/effect/turf_decal/bot,
+/obj/vehicle/ridden/secway,
+/obj/item/key/security,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light_switch/directional/west,
+/turf/open/floor/iron,
+/area/station/security/mechbay)
 "iDX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -23753,6 +23841,22 @@
 "iHu" = (
 /turf/closed/wall,
 /area/centcom/asteroid/nearstation/bomb_site)
+"iHM" = (
+/obj/machinery/door/poddoor/shutters{
+	dir = 8;
+	id = "secmechbay";
+	name = "Security Mech Bay Shutters"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/caution/stand_clear{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/mechbay)
 "iIc" = (
 /obj/machinery/light/small/directional/west,
 /obj/item/cigbutt,
@@ -24992,11 +25096,6 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "jjd" = (
-/obj/structure/sign/directions/evac{
-	dir = 8;
-	pixel_x = -32;
-	pixel_y = 8
-	},
 /obj/structure/sign/directions/security{
 	dir = 1;
 	pixel_x = -32
@@ -25009,6 +25108,10 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
+	},
+/obj/structure/sign/directions/evac/directional/west{
+	pixel_y = 8;
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
@@ -25070,9 +25173,13 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "jkr" = (
-/obj/effect/turf_decal/bot,
-/obj/vehicle/ridden/secway,
-/obj/item/key/security,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/lockers)
 "jks" = (
@@ -25667,6 +25774,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal/incinerator)
+"jAw" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/station/security/mechbay)
 "jAB" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -26001,6 +26113,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/disposal)
+"jJE" = (
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/machinery/light/directional/south,
+/obj/structure/tank_dispenser/oxygen,
+/obj/effect/turf_decal/bot,
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/iron/showroomfloor,
+/area/station/security/lockers)
 "jJI" = (
 /obj/effect/landmark/start/security_officer,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -29077,7 +29197,7 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/structure/sign/directions/evac{
-	dir = 1;
+	dir = 8;
 	pixel_x = 32
 	},
 /obj/structure/sign/directions/security{
@@ -29334,6 +29454,13 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"lmm" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/security/mechbay)
 "lmJ" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -30665,6 +30792,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
+"lPu" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/security/mechbay)
 "lPx" = (
 /obj/machinery/requests_console/directional/east{
 	department = "Security";
@@ -32021,12 +32156,11 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "mur" = (
-/obj/structure/sign/directions/evac{
-	dir = 8;
-	pixel_x = -32;
-	pixel_y = 8
-	},
 /obj/structure/cable,
+/obj/structure/sign/directions/evac/directional/west{
+	pixel_y = 8;
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "muv" = (
@@ -33051,6 +33185,13 @@
 "mVM" = (
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"mVW" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/station/security/mechbay)
 "mWo" = (
 /obj/structure/closet/crate/engineering/electrical,
 /obj/item/stack/cable_coil,
@@ -34578,12 +34719,11 @@
 /area/station/command/bridge)
 "nIi" = (
 /obj/machinery/light/directional/north,
-/obj/structure/sign/directions/evac{
-	dir = 1;
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
+	},
+/obj/structure/sign/directions/evac/directional/north{
+	dir = 8
 	},
 /turf/open/floor/iron/white/corner{
 	dir = 1
@@ -35475,7 +35615,7 @@
 	pixel_y = -24
 	},
 /obj/structure/sign/directions/evac{
-	dir = 1;
+	dir = 8;
 	pixel_x = -32;
 	pixel_y = -32
 	},
@@ -36013,10 +36153,8 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "ooO" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/security/lockers)
+/turf/closed/wall,
+/area/station/security/mechbay)
 "ooX" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -36963,6 +37101,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/structure/sign/departments/rndserver/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/science/lab)
 "oMn" = (
@@ -37012,6 +37151,13 @@
 /obj/effect/mapping_helpers/airlock/access/any/service/kitchen,
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/kitchen/coldroom)
+"oMY" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/security/mechbay)
 "oNd" = (
 /obj/machinery/requests_console/directional/south{
 	department = "Asset Protection's Chair";
@@ -37618,6 +37764,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"paJ" = (
+/obj/vehicle/sealed/mecha/ripley/paddy/preset,
+/turf/open/floor/iron/recharge_floor,
+/area/station/security/mechbay)
 "paK" = (
 /obj/structure/transit_tube/curved,
 /obj/structure/lattice/catwalk,
@@ -40024,13 +40174,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "qfo" = (
-/obj/machinery/requests_console/directional/west{
-	department = "Security";
-	name = "Security Lockers Requests Console"
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/effect/mapping_helpers/requests_console/information,
-/obj/effect/mapping_helpers/requests_console/assistance,
-/turf/closed/wall,
+/turf/open/floor/iron/showroomfloor,
 /area/station/security/lockers)
 "qfG" = (
 /obj/structure/disposalpipe/segment{
@@ -40655,6 +40804,9 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
+"qwQ" = (
+/turf/closed/wall,
+/area/space/nearstation)
 "qwR" = (
 /obj/machinery/light/small/directional/east,
 /obj/machinery/camera/directional/east{
@@ -41486,6 +41638,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/hos)
+"qQs" = (
+/mob/living/basic/bot/medbot/autopatrol,
+/turf/open/floor/iron/white,
+/area/station/medical/paramedic)
 "qQz" = (
 /obj/structure/sign/painting/library_private{
 	pixel_x = -32
@@ -44608,6 +44764,14 @@
 /obj/structure/flora/bush/leavy/style_random,
 /turf/open/misc/asteroid,
 /area/station/service/chapel/asteroid/monastery)
+"spN" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/station/security/mechbay)
 "spS" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -45603,7 +45767,7 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "sQM" = (
-/obj/structure/chair/sofa{
+/obj/structure/chair/sofa/middle{
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -47620,6 +47784,10 @@
 /obj/effect/mapping_helpers/airlock/access/any/science/rd,
 /turf/open/floor/iron/dark,
 /area/station/science/server)
+"tJn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/turf/closed/wall/r_wall,
+/area/station/science/ordnance)
 "tJr" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
@@ -47723,6 +47891,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
+"tNh" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/security/mechbay)
 "tNx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -48075,7 +48250,7 @@
 /area/station/hallway/secondary/entry)
 "tYR" = (
 /obj/structure/sign/directions/evac{
-	dir = 1;
+	dir = 8;
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/tile/green{
@@ -49706,6 +49881,18 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/warden)
+"uID" = (
+/obj/machinery/button/door/directional/west{
+	id = "secmechbay";
+	name = "Security Mech Garage Door Controls";
+	req_access = list("security")
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/mechbay)
 "uIP" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -50104,10 +50291,10 @@
 /turf/closed/wall,
 /area/station/commons/dorms/laundry)
 "uRb" = (
-/obj/structure/sign/directions/evac{
-	pixel_x = -32
-	},
 /obj/structure/cable,
+/obj/structure/sign/directions/evac/directional/west{
+	dir = 2
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "uRh" = (
@@ -52695,6 +52882,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine)
+"weg" = (
+/obj/machinery/mech_bay_recharge_port{
+	dir = 8
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/station/security/mechbay)
 "weO" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/records/medical/laptop,
@@ -55252,6 +55446,15 @@
 	},
 /turf/open/floor/carpet,
 /area/station/service/library/lounge)
+"xhp" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/camera/directional/west{
+	c_tag = "Security Mech Bay"
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/mechbay)
 "xhq" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -55637,6 +55840,18 @@
 	},
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai)
+"xqw" = (
+/obj/structure/table/reinforced,
+/obj/item/weldingtool/empty{
+	pixel_y = 3;
+	pixel_x = -5
+	},
+/obj/item/stack/cable_coil{
+	pixel_x = 3
+	},
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron,
+/area/station/security/mechbay)
 "xqI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/effect/spawner/structure/window/reinforced/plasma,
@@ -56515,8 +56730,12 @@
 /obj/machinery/airalarm/directional/north,
 /obj/effect/mapping_helpers/airalarm/engine_access,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/effect/mapping_helpers/airalarm/link{
+	chamber_id = "engine"
+	},
+/obj/effect/mapping_helpers/airalarm/tlv_no_checks,
 /turf/open/floor/engine,
-/area/station/engineering/supermatter)
+/area/station/engineering/supermatter/room)
 "xMq" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/hangover,
@@ -56636,6 +56855,10 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"xOl" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/dark,
+/area/station/security/mechbay)
 "xOv" = (
 /obj/structure/disposalpipe/junction{
 	dir = 8
@@ -83104,7 +83327,7 @@ aaa
 xLq
 oIw
 ttb
-uzd
+qfo
 uzd
 uzd
 hpR
@@ -83618,7 +83841,7 @@ aaa
 rly
 lle
 szU
-lzA
+eUt
 lzA
 eMv
 rly
@@ -83874,11 +84097,11 @@ dUd
 abI
 rly
 gsa
-szU
+eDF
 jkr
 cjN
+jJE
 rly
-qfo
 ajs
 ajs
 aeL
@@ -84127,15 +84350,15 @@ aaa
 aaa
 aaa
 aaa
+dUd
 aaa
-aaa
-rly
+ooO
+ooO
+diu
+iHM
 ooO
 ooO
 ooO
-rly
-rly
-abI
 ajs
 vcq
 ahb
@@ -84384,15 +84607,15 @@ aaa
 aaa
 aaa
 aaa
+dUd
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-abI
+ooO
+iDL
+lmm
+faU
+uID
+xhp
+cKt
 ajs
 vcK
 gJr
@@ -84641,15 +84864,15 @@ aaa
 aaa
 aaa
 aaa
+dUd
 aaa
-aaa
-aaa
-aaa
-aaa
-cFB
-aaa
-aaa
-abI
+ooO
+tNh
+oMY
+eAh
+iwa
+xOl
+paJ
 ajs
 omx
 fea
@@ -84898,15 +85121,15 @@ aaa
 aaa
 aaa
 aaa
+oel
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-abI
+ooO
+eLW
+lPu
+eAh
+mVW
+xOl
+weg
 ajs
 eEd
 fea
@@ -85155,15 +85378,15 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-abI
+bBW
+bBW
+ooO
+xqw
+spN
+iwa
+iwa
+jAw
+cHE
 ajs
 aiM
 fea
@@ -85414,13 +85637,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+ooO
+ooO
 aiR
+aiR
+aiR
+aiR
+ooO
 ajs
 ajs
 ndM
@@ -85678,8 +85901,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aiR
+qwQ
+aht
 abI
 abI
 abI
@@ -86181,7 +86404,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cFB
 aaa
 aaa
 aaa
@@ -86249,7 +86472,7 @@ kQm
 jze
 fPn
 ddZ
-jEI
+qQs
 lmS
 jze
 lbW
@@ -86441,7 +86664,7 @@ aaa
 aaa
 aaa
 aaa
-abN
+bBW
 aaa
 aaa
 aaa
@@ -99629,7 +99852,7 @@ nTW
 trJ
 wcK
 gAX
-hnh
+tJn
 hnh
 hnh
 iUX


### PR DESCRIPTION
## About The Pull Request
### Pubby:
- Fixed evac signs not pointing in the right direction 
- Added a sign outside of science's server room
- Swapped an access helper in the engineering lobby to use 'General' instead of 'Construction'
- Added Security Mech Bay
- Added sensors and updated air alarms in Supermatter Chambers and Ordnance facilities

### Lima:
- Moved the supermatter crystal delamination display screen to a more suitable location
- Added an auto-patrol medbot
- Added some desk bells
- Changed some unsightly air alarms to directional subtypes
- Added Security Mech Bay
- Added sensors and updated air alarms in Supermatter Chambers and Ordnance facilities

### Kilo:
- Removed a stray Byteforge out in space
- Added Security Mech Bay
- Added sensors and updated air alarms in Supermatter Chambers and Ordnance facilities

## How does it improve TaleStation
General map maintenance, as well as keeping maps up-to-date and streamlined with newly implemented features.
Closes #8918
Closes #6927
Closes #6535

## Changelog
:cl:
add: [Kilo, Lima, and Pubby] Added Security Mech Bays
add: [Kilo, Lima, and Pubby] Added air sensors to the ordnance facilities and supermatter chambers
add: [Lima, Pubby] Added an auto-patrolling medbot
add: [LimaStation] Added some desk bells
add: [PubbyStation] Added a sign outside the research server room
fix: [PubbyStation] Evac signs now point in the correct direction
fix: [PubbyStation] The engineering lobby now has the correct access restrictions
fix: [KiloStation] Removed a stray Byteforge in space
fix: [LimaStation] Moved the supermatter delamination counter display to another location so that it appears flush against the wall
/:cl: