### PR TITLE
Fixes Limbs prefs page

### DIFF
--- a/tgui/packages/tgui/interfaces/_LimbManager.tsx
+++ b/tgui/packages/tgui/interfaces/_LimbManager.tsx
@@ -244,7 +244,7 @@ class LimbPreview extends Component<PreviewProps, PreviewState> {
                 height={width}
                 width={height}
                 style={{
-                  PointerEvent: 'none',
+                  pointerEvents: 'none',
                   position: 'absolute',
                   zIndex: 3,
                 }}


### PR DESCRIPTION
Fixes: #8961

## Changelog

:cl: Jolly
fix: The limbs page in the prefs menu should no longer require a refresh to select other limbs.
/:cl: