### PR TITLE
Tweaks and fixes a resource cache goodie grate

### DIFF
--- a/talestation_modules/code/events_module/resource_drift/crates.dm
+++ b/talestation_modules/code/events_module/resource_drift/crates.dm
@@ -273,7 +273,7 @@
 
 /obj/structure/closet/crate/resource_cache/random_materials/Initialize(mapload)
 	for(var/i in 1 to rand(2, 4))
-		resources += list(pick(subtypesof(/obj/item/stack)) = round(rand(1, 50),5))
+		resources += list(pick(subtypesof(/obj/item/stack)) = round(rand(2, 20),2))
 	return ..()
 
 //---

--- a/talestation_modules/code/events_module/resource_drift/crates.dm
+++ b/talestation_modules/code/events_module/resource_drift/crates.dm
@@ -269,7 +269,8 @@
 // Yes, this crate can have literally any stack item.
 // No, it's blacklisted from the events that use it for a reason.
 /obj/structure/closet/crate/resource_cache/random_materials
-	desc = "A steel crate. This one seems like trouble."
+	storage_capacity = 60
+	desc = "A mysterious looking crate. It looks deeper on the inside."
 
 /obj/structure/closet/crate/resource_cache/random_materials/Initialize(mapload)
 	for(var/i in 1 to rand(2, 3))

--- a/talestation_modules/code/events_module/resource_drift/crates.dm
+++ b/talestation_modules/code/events_module/resource_drift/crates.dm
@@ -272,7 +272,7 @@
 	desc = "A steel crate. This one seems like trouble."
 
 /obj/structure/closet/crate/resource_cache/random_materials/Initialize(mapload)
-	for(var/i in 1 to rand(2, 4))
+	for(var/i in 1 to rand(2, 3))
 		resources += list(pick(subtypesof(/obj/item/stack)) = round(rand(2, 20),2))
 	return ..()
 


### PR DESCRIPTION
I don't know why this crate was triggering the crates, but if it does trigger the unit test again later I'll tweak the code further.

Also, it no longer runs up to 4 times, which I think was the major issue.

Fixes: #9517
Fixes: #9224
Fixes: #9213
Fixes: #9136
Fixes: #9121
Fixes: #9049
Fixes: #8782
Fixes: #8726
Fixes: #8723
Fixes: #8677
Fixes: #8646
Fixes: #8575
Fixes: #8537

## Changelog

N/A since this crate is inaccessible.