### PR TITLE
Connecting Pubby's Mining Dock APC to the grid

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -6368,11 +6368,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/science/minisat,
 /turf/open/floor/iron/white,
 /area/station/ai_monitored/turret_protected/ai)
-"bpi" = (
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
 "bpo" = (
 /turf/open/floor/engine,
 /area/station/science/lab)
@@ -34304,6 +34299,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
+"nvy" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "nvH" = (
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/morgue)
@@ -98910,7 +98909,7 @@ bbK
 gSq
 fwq
 fpd
-bpi
+nvy
 tHH
 fPl
 uAD

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -1847,6 +1847,7 @@
 	pixel_x = 3
 	},
 /obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/cargo/miningdock)
 "avl" = (
@@ -6367,6 +6368,11 @@
 /obj/effect/mapping_helpers/airlock/access/any/science/minisat,
 /turf/open/floor/iron/white,
 /area/station/ai_monitored/turret_protected/ai)
+"bpi" = (
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "bpo" = (
 /turf/open/floor/engine,
 /area/station/science/lab)
@@ -16865,6 +16871,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
@@ -17147,6 +17154,7 @@
 /area/station/science/ordnance)
 "fwq" = (
 /obj/machinery/holopad,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/cargo/miningdock)
 "fwu" = (
@@ -98902,7 +98910,7 @@ bbK
 gSq
 fwq
 fpd
-sml
+bpi
 tHH
 fPl
 uAD


### PR DESCRIPTION
## About The Pull Request
Adds wires leading to the APC displayed in the attached image.

![image](https://github.com/TaleStation/TaleStation/assets/105393050/75d3cbe5-1a96-4f1c-9c0e-a13a30db9f60)
![image](https://github.com/TaleStation/TaleStation/assets/105393050/bab67556-0470-4579-b43c-8c1bb0d3cd50)

## How does it improve TaleStation
Studies show that miner productivity increases when the mining dock is supplied with power.

## Changelog

:cl:
fix: The APC in Pubbystation's Mining Dock is now wired to the station's grid.
/:cl:
