### PR TITLE
Secbots no longer hold prejudice against non-humans

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -413,10 +413,6 @@
 	if(istype(head, /obj/item/clothing/head/wizard))
 		threatcount += 2
 
-	//Check for nonhuman scum
-	if(dna && dna.species.id && dna.species.id != SPECIES_HUMAN)
-		threatcount += 1
-
 	//mindshield implants imply trustworthyness
 	if(HAS_TRAIT(src, TRAIT_MINDSHIELD))
 		threatcount -= 1


### PR DESCRIPTION
Been meaning to get to this some day. Here we are!

## Changelog

:cl: Jolly
balance: Secbots no longer harbor a small prejudice against non-human species. They will still, however, attack you if you're breaking the law.
/:cl:

