### PR TITLE
Makes the restricted number input user friendlier 

### DIFF
--- a/tgui/packages/tgui/components/RestrictedInput.jsx
+++ b/tgui/packages/tgui/components/RestrictedInput.jsx
@@ -9,6 +9,119 @@ const DEFAULT_MIN = 0;
 const DEFAULT_MAX = 10000;
 
 /**
+ * Sanitize a number without interfering with writing negative or floating point numbers.
+ * Handling dots and minuses in a user friendly way
+ * @param value {String}
+ * @param minValue {Number}
+ * @param maxValue {Number}
+ * @param allowFloats {Boolean}
+ * @returns {String}
+ */
+const softSanitizeNumber = (value, minValue, maxValue, allowFloats) => {
+  const minimum = minValue || DEFAULT_MIN;
+  const maximum = maxValue || maxValue === 0 ? maxValue : DEFAULT_MAX;
+
+  let sanitizedString = allowFloats
+    ? value.replace(/[^\-\d.]/g, '')
+    : value.replace(/[^\-\d]/g, '');
+
+  if (allowFloats) {
+    sanitizedString = maybeLeadWithMin(sanitizedString, minimum);
+    sanitizedString = keepOnlyFirstOccurrence('.', sanitizedString);
+  }
+  if (minValue < 0) {
+    sanitizedString = maybeMoveMinusSign(sanitizedString);
+    sanitizedString = keepOnlyFirstOccurrence('-', sanitizedString);
+  } else {
+    sanitizedString = sanitizedString.replaceAll('-', '');
+  }
+  if (minimum <= 1 && maximum >= 0) {
+    return clampGuessedNumber(sanitizedString, minimum, maximum, allowFloats);
+  }
+  return sanitizedString;
+};
+
+/**
+ * Clamping the input to the restricted range, making the Input smart for min <= 1 and max >= 0
+ * @param softSanitizedNumber {String}
+ * @param allowFloats {Boolean}
+ * @returns {string}
+ */
+const clampGuessedNumber = (
+  softSanitizedNumber,
+  minValue,
+  maxValue,
+  allowFloats,
+) => {
+  let parsed = allowFloats
+    ? parseFloat(softSanitizedNumber)
+    : parseInt(softSanitizedNumber, 10);
+  if (
+    !isNaN(parsed) &&
+    (softSanitizedNumber.slice(-1) !== '.' || parsed < Math.floor(minValue))
+  ) {
+    let clamped = clamp(parsed, minValue, maxValue);
+    if (parsed !== clamped) {
+      return String(clamped);
+    }
+  }
+  return softSanitizedNumber;
+};
+
+/**
+ * Translate x- to -x and -x- to x
+ * @param string {String}
+ * @returns {string}
+ */
+const maybeMoveMinusSign = (string) => {
+  let retString = string;
+  // if minus sign is present but not first
+  let minusIdx = string.indexOf('-');
+  if (minusIdx > 0) {
+    string = string.replace('-', '');
+    retString = '-'.concat(string);
+  } else if (minusIdx === 0) {
+    if (string.indexOf('-', minusIdx + 1) > 0) {
+      retString = string.replaceAll('-', '');
+    }
+  }
+  return retString;
+};
+
+/**
+ * Translate . to min. or .x to mim.x or -. to -min.
+ * @param string {String}
+ */
+const maybeLeadWithMin = (string, min) => {
+  let retString = string;
+  let cuttedVal = Math.sign(min) * Math.floor(Math.abs(min));
+  if (string.indexOf('.') === 0) {
+    retString = String(cuttedVal).concat(string);
+  } else if (string.indexOf('-') === 0 && string.indexOf('.') === 1) {
+    retString = cuttedVal + '.'.concat(string.slice(2));
+  }
+  return retString;
+};
+
+/**
+ * Keep only the first occurrence of a string in another string.
+ * @param needle {String}
+ * @param haystack {String}
+ * @returns {string}
+ */
+const keepOnlyFirstOccurrence = (needle, haystack) => {
+  const idx = haystack.indexOf(needle);
+  const len = haystack.length;
+  let newHaystack = haystack;
+  if (idx !== -1 && idx < len - 1) {
+    let trailingString = haystack.slice(idx + 1, len);
+    trailingString = trailingString.replaceAll(needle, '');
+    newHaystack = haystack.slice(0, idx + 1).concat(trailingString);
+  }
+  return newHaystack;
+};
+
+/**
  * Takes a string input and parses integers or floats from it.
  * If none: Minimum is set.
  * Else: Clamps it to the given range.
@@ -37,14 +150,24 @@ export class RestrictedInput extends Component {
       editing: false,
     };
     this.handleBlur = (e) => {
+      const { maxValue, minValue, onBlur, allowFloats } = this.props;
       const { editing } = this.state;
       if (editing) {
         this.setEditing(false);
       }
+      const safeNum = getClampedNumber(
+        e.target.value,
+        minValue,
+        maxValue,
+        allowFloats,
+      );
+      if (onBlur) {
+        onBlur(e, +safeNum);
+      }
     };
     this.handleChange = (e) => {
       const { maxValue, minValue, onChange, allowFloats } = this.props;
-      e.target.value = getClampedNumber(
+      e.target.value = softSanitizeNumber(
         e.target.value,
         minValue,
         maxValue,
@@ -149,7 +272,7 @@ export class RestrictedInput extends Component {
 
   render() {
     const { props } = this;
-    const { onChange, onEnter, onInput, value, ...boxProps } = props;
+    const { onChange, onEnter, onInput, onBlur, value, ...boxProps } = props;
     const { className, fluid, monospace, ...rest } = boxProps;
     return (
       <Box
@@ -170,7 +293,7 @@ export class RestrictedInput extends Component {
           onBlur={this.handleBlur}
           onKeyDown={this.handleKeyDown}
           ref={this.inputRef}
-          type="number"
+          type="number | string"
         />
       </Box>
     );

--- a/tgui/packages/tgui/interfaces/NumberInputModal.tsx
+++ b/tgui/packages/tgui/interfaces/NumberInputModal.tsx
@@ -55,7 +55,12 @@ export const NumberInputModal = (props) => {
               <Box color="label">{message}</Box>
             </Stack.Item>
             <Stack.Item>
-              <InputArea input={input} onClick={setValue} onChange={setValue} />
+              <InputArea
+                input={input}
+                onClick={setValue}
+                onChange={setValue}
+                onBlur={setValue}
+              />
             </Stack.Item>
             <Stack.Item>
               <InputButtons input={input} />
@@ -71,7 +76,7 @@ export const NumberInputModal = (props) => {
 const InputArea = (props) => {
   const { act, data } = useBackend<NumberInputData>();
   const { min_value, max_value, init_value, round_value } = data;
-  const { input, onClick, onChange } = props;
+  const { input, onClick, onChange, onBlur } = props;
 
   return (
     <Stack fill>
@@ -92,6 +97,7 @@ const InputArea = (props) => {
           minValue={min_value}
           maxValue={max_value}
           onChange={(_, value) => onChange(value)}
+          onBlur={(_, value) => onBlur(value)}
           onEnter={(_, value) => act('submit', { entry: value })}
           value={input}
         />


### PR DESCRIPTION
Port of https://github.com/tgstation/tgstation/pull/81495

## Changelog

:cl: Kashargul
qol: makes the tgui_input_number user friendly for negative and decimal inputs
code: the onBlur={(_, value) => onBlur(value)} event should now be used on all uses of RestrictedInput to ensure that the number is fully sanitized whenever the user leaves the field or submits it through a button
/:cl:
