### PR TITLE
Adds text to lootpanel items + Lootpanel: Requires 515.1635+

### DIFF
--- a/.tgs.yml
+++ b/.tgs.yml
@@ -3,7 +3,7 @@
 version: 1
 # The BYOND version to use (kept in sync with dependencies.sh by the "TGS Test Suite" CI job)
 # Must be interpreted as a string, keep quoted
-byond: "515.1630"
+byond: "515.1637"
 # Folders to create in "<instance_path>/Configuration/GameStaticFiles/"
 static_files:
   # Config directory should be static

--- a/code/modules/lootpanel/search_object.dm
+++ b/code/modules/lootpanel/search_object.dm
@@ -50,6 +50,7 @@
 	var/build = owner.byond_build
 	var/version = owner.byond_version
 	if(build < 515 || (build == 515 && version < 1635))
+		icon = "n/a"
 		return
 
 	icon = "[item.icon]"
@@ -64,10 +65,7 @@
 
 /// Generates the icon for the search object. This is the expensive part.
 /datum/search_object/proc/generate_icon(client/owner)
-	if(ismob(item) || length(item.overlays) > 2)
-		icon = costly_icon2html(item, owner, sourceonly = TRUE)
-	else // our pre 515.1635 fallback for normal items
-		icon = icon2html(item, owner, sourceonly = TRUE)
+	icon = costly_icon2html(item, owner, sourceonly = TRUE)
 
 
 /// Parent item has been altered, search object no longer valid

--- a/config/config.txt
+++ b/config/config.txt
@@ -369,14 +369,14 @@ AUTOADMIN_RANK Game Master
 ## These trigger for any version below (non-inclusive) the given version, so 510 triggers on 509 or lower.
 ## These messages will be followed by one stating the clients current version and the required version for clarity.
 ## If CLIENT_WARN_POPUP is uncommented a popup window with the message will be displayed instead
-#CLIENT_WARN_VERSION 511
-#CLIENT_WARN_BUILD 1421
+#CLIENT_WARN_VERSION 515
+#CLIENT_WARN_BUILD 1635
 #CLIENT_WARN_POPUP
-#CLIENT_WARN_MESSAGE Byond released 511 as the stable release. You can set the framerate your client runs at, which makes the game feel very different and cool. Shortly after its release we will end up using 511 client features and you will be forced to update.
-CLIENT_ERROR_VERSION 511
+#CLIENT_WARN_MESSAGE Byond released 515 as the stable release. This comes bundled with a host of niceties, including image generation for UIs and :: operators.
+CLIENT_ERROR_VERSION 515
 CLIENT_ERROR_MESSAGE Your version of byond is not supported. Please upgrade.
-## The minimum build needed for joining the server, if using 512, a good minimum build would be 1421 as that disables the Middle Mouse Button exploit.
-CLIENT_ERROR_BUILD 1421
+## The minimum build needed for joining the server.
+CLIENT_ERROR_BUILD 1590
 
 ## TOPIC RATE LIMITING
 ## This allows you to limit how many topic calls (clicking on an interface window) the client can do in any given game second and/or game minute.

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -5,7 +5,7 @@
 
 # byond version
 export BYOND_MAJOR=515
-export BYOND_MINOR=1630
+export BYOND_MINOR=1637
 
 #rust_g git tag
 export RUST_G_VERSION=3.1.0

--- a/tgui/packages/tgui/interfaces/LootPanel/IconDisplay.tsx
+++ b/tgui/packages/tgui/interfaces/LootPanel/IconDisplay.tsx
@@ -16,6 +16,10 @@ export function IconDisplay(props: Props) {
     return fallback;
   }
 
+  if (icon === 'n/a') {
+    return <Icon name="dumpster-fire" size={2} color="gray" />;
+  }
+
   if (icon_state) {
     return (
       // @ts-ignore

--- a/tgui/packages/tgui/interfaces/LootPanel/IconDisplay.tsx
+++ b/tgui/packages/tgui/interfaces/LootPanel/IconDisplay.tsx
@@ -10,17 +10,25 @@ export function IconDisplay(props: Props) {
     item: { icon, icon_state },
   } = props;
 
-  const fallback = <Icon name="spinner" size={2.4} spin color="gray" />;
+  const fallback = <Icon name="spinner" size={2.2} spin color="gray" />;
 
   if (!icon) {
     return fallback;
   }
 
   if (icon_state) {
-    // @ts-ignore
-    // figure out why this causes ts lints to fail, it works so its not a problem?
-    return <DmIcon fallback={fallback} icon={icon} icon_state={icon_state} />;
+    return (
+      // @ts-ignore
+      // figure out why this causes ts lints to fail, it works so its not a problem?
+      <DmIcon
+        fallback={fallback}
+        icon={icon}
+        icon_state={icon_state}
+        height={3}
+        width={3}
+      />
+    );
   }
 
-  return <Image fixErrors src={icon} />;
+  return <Image fixErrors src={icon} height={3} width={3} />;
 }

--- a/tgui/packages/tgui/interfaces/LootPanel/LootBox.tsx
+++ b/tgui/packages/tgui/interfaces/LootPanel/LootBox.tsx
@@ -1,4 +1,4 @@
-import { capitalizeAll } from 'common/string';
+import { capitalizeAll, capitalizeFirst } from 'common/string';
 
 import { useBackend } from '../../backend';
 import { Tooltip } from '../../components';
@@ -25,28 +25,35 @@ export function LootBox(props: Props) {
     item = props.item;
   }
 
+  const name = !item.name
+    ? '???'
+    : capitalizeFirst(item.name.split(' ')[0]).slice(0, 5);
+
   return (
     <Tooltip content={capitalizeAll(item.name)}>
-      <div
-        className="SearchItem"
-        onClick={(event) =>
-          act('grab', {
-            ctrl: event.ctrlKey,
-            ref: item.ref,
-            shift: event.shiftKey,
-          })
-        }
-        onContextMenu={(event) => {
-          event.preventDefault();
-          act('grab', {
-            middle: true,
-            ref: item.ref,
-            shift: true,
-          });
-        }}
-      >
-        <IconDisplay item={item} />
-        {amount > 1 && <div className="SearchItem--amount">{amount}</div>}
+      <div className="SearchItem">
+        <div
+          className="SearchItem--box"
+          onClick={(event) =>
+            act('grab', {
+              ctrl: event.ctrlKey,
+              ref: item.ref,
+              shift: event.shiftKey,
+            })
+          }
+          onContextMenu={(event) => {
+            event.preventDefault();
+            act('grab', {
+              middle: true,
+              ref: item.ref,
+              shift: true,
+            });
+          }}
+        >
+          <IconDisplay item={item} />
+          {amount > 1 && <div className="SearchItem--amount">{amount}</div>}
+        </div>
+        <span className="SearchItem--text">{name}</span>
       </div>
     </Tooltip>
   );

--- a/tgui/packages/tgui/interfaces/LootPanel/index.tsx
+++ b/tgui/packages/tgui/interfaces/LootPanel/index.tsx
@@ -24,7 +24,7 @@ export function LootPanel(props) {
   const total = contents.length ? contents.length - 1 : 0;
 
   return (
-    <Window height={250} width={190} title={`Contents: ${total}`}>
+    <Window height={275} width={190} title={`Contents: ${total}`}>
       <Window.Content
         onKeyDown={(event) => {
           if (event.key === KEY.Escape) {

--- a/tgui/packages/tgui/styles/components/SearchItem.scss
+++ b/tgui/packages/tgui/styles/components/SearchItem.scss
@@ -2,21 +2,34 @@
 
 .SearchItem {
   align-items: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.SearchItem--box {
   background: black;
   border: thin solid #212121;
   display: flex;
-  height: 3rem;
+  align-items: center;
   justify-content: center;
+  height: 3rem;
   position: relative;
   width: 3rem;
-  margin-bottom: 0;
 }
 
 .SearchItem--amount {
-  bottom: -1rem;
+  bottom: -4px;
   color: colors.$teal;
   font-family: 'Roboto', sans-serif;
   font-size: 1.5rem;
   position: absolute;
-  right: -4px;
+  right: -6px;
+}
+
+.SearchItem--text {
+  color: colors.$label;
+  font-family: 'Roboto', sans-serif;
+  font-size: 1rem;
+  z-index: 1;
 }


### PR DESCRIPTION
Dual port of https://github.com/tgstation/tgstation/pull/82722 and https://github.com/tgstation/tgstation/pull/83084
---

## Changelog

:cl: jlsnow301
fix: Lootpanel additions: Condensed item names for the quick of draw
fix: Lootpanel now requires 515.1635 to generate most icons. TG support for 514 ended May 1. Update your client to fix the icons.
/:cl:
