### PR TITLE
Removes duplicate extinguisher cabinet (LimaStation)

### DIFF
--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -37383,7 +37383,6 @@
 /area/station/maintenance/port/lower)
 "oqc" = (
 /obj/structure/extinguisher_cabinet/directional/south,
-/obj/structure/extinguisher_cabinet/directional/south,
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/dark/side{
 	dir = 8


### PR DESCRIPTION
## About The Pull Request

Removes a duplicate extinguisher cabinet
![dupe_extinguisher](https://github.com/user-attachments/assets/bcafe249-a93d-4a16-83b7-f8c7b22c9738)


## How does it improve TaleStation

Mapping error, begone!

## Changelog

:cl:
fix: Removed duplicate fire extinguisher cabinet in LimaStation cargo
/:cl:
