### PR TITLE
Quick CODEOWNERS adjustment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,8 +7,6 @@
 # Org Teams
 
 # Lore
-/talestation_modules/code/species_module/ @talestation/Loretainers
-/talestation_modules/icons/species/ @talestation/Loretainers
 
 # Maps
 /_maps/ @talestation/Maptainers
@@ -18,6 +16,7 @@
 /talestation_modules/code/mapping_module @talestation/Maptainers
 
 # Icons
+/icons/ @talestation/Spritetainers
 /talestation_modules/icons/ @talestation/Spritetainers
 
 # Jolly66


### PR DESCRIPTION
Removes the lore team since the read-only action can't take from org members.

Adds base `/icons/` folder to the Spritetainers codeowners. 